### PR TITLE
[Design] 고객용 어플 입장 화면 레이아웃 추가

### DIFF
--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		260A63E629710A5C004034AD /* SubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63E529710A5C004034AD /* SubViewController.swift */; };
 		260A63E829710A7F004034AD /* SubCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63E729710A7F004034AD /* SubCoordinator.swift */; };
 		260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63E929711307004034AD /* BaseCoordinator.swift */; };
+		260A63F22975E01F004034AD /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63F12975E01F004034AD /* SplashViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
 		98D44B7B2941DD4D00386AA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98D44B7A2941DD4D00386AA4 /* Assets.xcassets */; };
@@ -40,6 +41,7 @@
 		260A63E729710A7F004034AD /* SubCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubCoordinator.swift; sourceTree = "<group>"; };
 		260A63E929711307004034AD /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		260A63EB297118A8004034AD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		260A63F12975E01F004034AD /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 				98D44B7C2941DD4D00386AA4 /* LaunchScreen.storyboard */,
 				260A63E329710A45004034AD /* MainViewController.swift */,
 				260A63E529710A5C004034AD /* SubViewController.swift */,
+				260A63F12975E01F004034AD /* SplashViewController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				260A63E629710A5C004034AD /* SubViewController.swift in Sources */,
 				260A63E229710846004034AD /* MainCoordinator.swift in Sources */,
 				260A63E829710A7F004034AD /* SubCoordinator.swift in Sources */,
+				260A63F22975E01F004034AD /* SplashViewController.swift in Sources */,
 				260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */,
 				98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */,
 				98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */,

--- a/GiwazipClient/Views/SplashViewController.swift
+++ b/GiwazipClient/Views/SplashViewController.swift
@@ -19,7 +19,6 @@ class SplashViewController: BaseViewController {
         $0.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         $0.backgroundColor = .gray
         $0.layer.cornerRadius = 16
-
         return $0
     }(UIButton())
 

--- a/GiwazipClient/Views/SplashViewController.swift
+++ b/GiwazipClient/Views/SplashViewController.swift
@@ -1,0 +1,37 @@
+//
+//  SplashViewController.swift
+//  GiwazipClient
+//
+//  Created by 김민택 on 2023/01/17.
+//
+
+import UIKit
+import SnapKit
+
+class SplashViewController: BaseViewController {
+
+    // MARK: - Property
+
+    private let enterButton: UIButton = {
+        $0.setTitle("입장하기", for: .normal)
+        $0.setTitleColor(.black, for: .normal)
+        $0.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        $0.backgroundColor = .gray
+        $0.layer.cornerRadius = 16
+
+        return $0
+    }(UIButton())
+
+    // MARK: - Method
+
+    override func layout() {
+        super.layout()
+
+        view.addSubview(enterButton)
+        enterButton.snp.makeConstraints { make in
+            make.left.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.right.bottom.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(50)
+        }
+    }
+}

--- a/GiwazipClient/Views/SplashViewController.swift
+++ b/GiwazipClient/Views/SplashViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+
 import SnapKit
 
 class SplashViewController: BaseViewController {

--- a/GiwazipClient/Views/SplashViewController.swift
+++ b/GiwazipClient/Views/SplashViewController.swift
@@ -29,10 +29,9 @@ class SplashViewController: BaseViewController {
         super.layout()
 
         view.addSubview(enterButton)
-        enterButton.snp.makeConstraints { make in
-            make.left.equalTo(view.safeAreaLayoutGuide).offset(16)
-            make.right.bottom.equalTo(view.safeAreaLayoutGuide).offset(-16)
-            make.height.equalTo(50)
+        enterButton.snp.makeConstraints {
+            $0.left.right.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.height.equalTo(50)
         }
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 고객용 어플에서 첫 화면을 보여주기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- SplashView 추가

## ToDo 📆 (남은 작업)
- [ ] 버튼을 눌렀을 때, 초대 코드 입력 뷰로 넘어가는 기능 추가
- [ ] 화면 상단에 로고 추가
- [ ] 화면 배경색 변경

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/212759129-55bd209c-02e8-4ede-af3b-1c6b91df3556.png" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 레이아웃 추가 PR 입니다.
- 아주 간단한 코드이므로, 가볍게 확인해주셔도 좋습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
- Close #9.
