### PR TITLE
[Design] HistoryView 레이아웃

### DIFF
--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		260A63F22975E01F004034AD /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63F12975E01F004034AD /* SplashViewController.swift */; };
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
 		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
+		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
 		98D44B7B2941DD4D00386AA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98D44B7A2941DD4D00386AA4 /* Assets.xcassets */; };
@@ -46,7 +47,7 @@
 		260A63F12975E01F004034AD /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		438BF0422977CA28005E4CF3 /* EnterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
-		988C56CF29768F2D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
+		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		98D44B732941DD4B00386AA4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -86,6 +87,7 @@
 				260A63F12975E01F004034AD /* SplashViewController.swift */,
 				438BF0422977CA28005E4CF3 /* EnterViewController.swift */,
 				988C56CF29768F2D00018F07 /* HistoryViewController.swift */,
+				988C56CF29768F2D00018F07 /* SegmentViewController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -320,7 +322,7 @@
 				260A63E029710834004034AD /* AppCoordinator.swift in Sources */,
 				260A63D429710784004034AD /* ViewModel.swift in Sources */,
 				260A63DE297107E4004034AD /* Extension+.swift in Sources */,
-				988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */,
+				988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */,
 				260A63E429710A45004034AD /* MainViewController.swift in Sources */,
 				260A63DA297107B8004034AD /* Service.swift in Sources */,
 				438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
 		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
+		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
 		988C56DC2978349D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56DB2978349D00018F07 /* HistoryViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
@@ -49,6 +50,7 @@
 		438BF0422977CA28005E4CF3 /* EnterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
+		988C56D32976D3BA00018F07 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
 		988C56DB2978349D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				260A63D7297107AA004034AD /* Cell.swift */,
+				988C56D32976D3BA00018F07 /* HistoryCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -330,6 +333,7 @@
 				260A63E429710A45004034AD /* MainViewController.swift in Sources */,
 				260A63DA297107B8004034AD /* Service.swift in Sources */,
 				438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */,
+				988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */,
 				260A63D8297107AA004034AD /* Cell.swift in Sources */,
 				260A63E629710A5C004034AD /* SubViewController.swift in Sources */,
 				260A63E229710846004034AD /* MainCoordinator.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
 		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
+		988C56DC2978349D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56DB2978349D00018F07 /* HistoryViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
 		98D44B7B2941DD4D00386AA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98D44B7A2941DD4D00386AA4 /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		438BF0422977CA28005E4CF3 /* EnterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
+		988C56DB2978349D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		98D44B732941DD4B00386AA4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 				438BF0422977CA28005E4CF3 /* EnterViewController.swift */,
 				988C56CF29768F2D00018F07 /* HistoryViewController.swift */,
 				988C56CF29768F2D00018F07 /* SegmentViewController.swift */,
+				988C56DB2978349D00018F07 /* HistoryViewController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -322,6 +325,7 @@
 				260A63E029710834004034AD /* AppCoordinator.swift in Sources */,
 				260A63D429710784004034AD /* ViewModel.swift in Sources */,
 				260A63DE297107E4004034AD /* Extension+.swift in Sources */,
+				988C56DC2978349D00018F07 /* HistoryViewController.swift in Sources */,
 				988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */,
 				260A63E429710A45004034AD /* MainViewController.swift in Sources */,
 				260A63DA297107B8004034AD /* Service.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
+		988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D7297777E500018F07 /* ProgressHeader.swift */; };
 		988C56DA29779D2A00018F07 /* PostDateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D929779D2A00018F07 /* PostDateCell.swift */; };
 		988C56DC2978349D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56DB2978349D00018F07 /* HistoryViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
@@ -52,6 +53,7 @@
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
 		988C56D32976D3BA00018F07 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
+		988C56D7297777E500018F07 /* ProgressHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHeader.swift; sourceTree = "<group>"; };
 		988C56D929779D2A00018F07 /* PostDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDateCell.swift; sourceTree = "<group>"; };
 		988C56DB2978349D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -121,6 +123,7 @@
 			isa = PBXGroup;
 			children = (
 				260A63D7297107AA004034AD /* Cell.swift */,
+				988C56D7297777E500018F07 /* ProgressHeader.swift */,
 				988C56D929779D2A00018F07 /* PostDateCell.swift */,
 				988C56D32976D3BA00018F07 /* HistoryCell.swift */,
 			);
@@ -344,6 +347,7 @@
 				260A63F22975E01F004034AD /* SplashViewController.swift in Sources */,
 				260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */,
 				98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */,
+				988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */,
 				98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */,
 				260A63CA29710725004034AD /* Model.swift in Sources */,
 				988C56DA29779D2A00018F07 /* PostDateCell.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63E929711307004034AD /* BaseCoordinator.swift */; };
 		260A63F22975E01F004034AD /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63F12975E01F004034AD /* SplashViewController.swift */; };
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
+		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
 		98D44B7B2941DD4D00386AA4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98D44B7A2941DD4D00386AA4 /* Assets.xcassets */; };
@@ -45,6 +46,7 @@
 		260A63F12975E01F004034AD /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		438BF0422977CA28005E4CF3 /* EnterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
+		988C56CF29768F2D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		98D44B732941DD4B00386AA4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 				260A63E529710A5C004034AD /* SubViewController.swift */,
 				260A63F12975E01F004034AD /* SplashViewController.swift */,
 				438BF0422977CA28005E4CF3 /* EnterViewController.swift */,
+				988C56CF29768F2D00018F07 /* HistoryViewController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				260A63E029710834004034AD /* AppCoordinator.swift in Sources */,
 				260A63D429710784004034AD /* ViewModel.swift in Sources */,
 				260A63DE297107E4004034AD /* Extension+.swift in Sources */,
+				988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */,
 				260A63E429710A45004034AD /* MainViewController.swift in Sources */,
 				260A63DA297107B8004034AD /* Service.swift in Sources */,
 				438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
+		988C56DA29779D2A00018F07 /* PostDateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D929779D2A00018F07 /* PostDateCell.swift */; };
 		988C56DC2978349D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56DB2978349D00018F07 /* HistoryViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
@@ -51,6 +52,7 @@
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
 		988C56D32976D3BA00018F07 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
+		988C56D929779D2A00018F07 /* PostDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDateCell.swift; sourceTree = "<group>"; };
 		988C56DB2978349D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				260A63D7297107AA004034AD /* Cell.swift */,
+				988C56D929779D2A00018F07 /* PostDateCell.swift */,
 				988C56D32976D3BA00018F07 /* HistoryCell.swift */,
 			);
 			path = Cells;
@@ -343,6 +346,7 @@
 				98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */,
 				98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */,
 				260A63CA29710725004034AD /* Model.swift in Sources */,
+				988C56DA29779D2A00018F07 /* PostDateCell.swift in Sources */,
 				260A63DC297107C3004034AD /* BaseViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63E929711307004034AD /* BaseCoordinator.swift */; };
 		260A63F22975E01F004034AD /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63F12975E01F004034AD /* SplashViewController.swift */; };
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
-		988C56D029768F2D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* HistoryViewController.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
 		988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D7297777E500018F07 /* ProgressHeader.swift */; };
@@ -94,7 +93,6 @@
 				260A63E529710A5C004034AD /* SubViewController.swift */,
 				260A63F12975E01F004034AD /* SplashViewController.swift */,
 				438BF0422977CA28005E4CF3 /* EnterViewController.swift */,
-				988C56CF29768F2D00018F07 /* HistoryViewController.swift */,
 				988C56CF29768F2D00018F07 /* SegmentViewController.swift */,
 				988C56DB2978349D00018F07 /* HistoryViewController.swift */,
 			);

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -42,8 +42,7 @@ class HistoryCell: UICollectionViewCell {
     }(UIImageView())
     
     private let descriptionBackground: UIView = {
-        $0.backgroundColor = .black
-        $0.layer.opacity = 0.7
+        $0.backgroundColor = UIColor(white: 0, alpha: 0.7)
         return $0
     }(UIView())
     
@@ -95,9 +94,10 @@ class HistoryCell: UICollectionViewCell {
             $0.bottom.width.equalToSuperview()
         }
         
+        descriptionBackground.addSubview(postDescription)
         postDescription.snp.makeConstraints {
-            $0.verticalEdges.equalTo(descriptionBackground).inset(12)
-            $0.horizontalEdges.equalTo(descriptionBackground).inset(16)
+            $0.verticalEdges.equalToSuperview().inset(12)
+            $0.horizontalEdges.equalToSuperview().inset(16)
         }
     }
 }

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -18,7 +18,7 @@ class HistoryCell: UICollectionViewCell {
     private let chipFrame: UIView = {
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 16
-        $0.layer.borderColor = CGColor.init(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+        $0.layer.borderColor = UIColor.black.cgColor
         $0.layer.borderWidth = 2
         $0.layer.opacity = 0.8
         return $0

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -1,0 +1,109 @@
+//
+//  HistoryCell.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/17.
+//
+
+import UIKit
+
+class HistoryCell: UICollectionViewCell {
+    
+    // MARK: - Property
+    
+    static let identifier = "historyCell"
+    
+    // MARK: - View
+    
+    private let chipFrame: UIView = {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 16
+        $0.layer.borderColor = CGColor.init(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+        $0.layer.borderWidth = 2
+        $0.layer.opacity = 0.8
+        return $0
+    }(UIView())
+    
+    private let chipLabel: UILabel = {
+        $0.text = "카테고리"
+        $0.textColor = .black
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        return $0
+    }(UILabel())
+    
+    private let postImage: UIImageView = {
+        $0.image = UIImage(systemName: "gearshape")
+        $0.backgroundColor = .green
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = 16
+        return $0
+    }(UIImageView())
+    
+    private let descriptionBackground: UIView = {
+        $0.backgroundColor = .black
+        $0.layer.opacity = 0.7
+        return $0
+    }(UIView())
+    
+    private let postDescription: UILabel = {
+        $0.text = "TEST용TEXT TEST용TEXT TEST용TEXT TEST용TEXT TEST용TEXT TEST용TEXT TEST용TEXT TEST용TEXT"
+        $0.textColor = .white
+        $0.textAlignment = .left
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.numberOfLines = 2
+        return $0
+    }(UILabel())
+    
+    // MARK: - LifeCycle
+    
+    override private init(frame: CGRect) {
+        super.init(frame: frame)
+        setupCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
+    
+    private func setupCell() {
+        self.addSubview(postImage)
+        postImage.addSubview(chipFrame)
+        postImage.addSubview(chipLabel)
+        postImage.addSubview(descriptionBackground)
+        postImage.addSubview(postDescription)
+        
+        postImage.snp.makeConstraints {
+            $0.top.equalTo(snp.top)
+            $0.left.equalTo(snp.left).offset(16)
+            $0.right.equalTo(snp.right).offset(-16)
+            $0.height.equalTo(UIScreen.main.bounds.width / 4 * 3)
+        }
+        
+        chipFrame.snp.makeConstraints {
+            $0.topMargin.equalTo(8)
+            $0.leftMargin.equalTo(8)
+        }
+        
+        chipLabel.snp.makeConstraints {
+            $0.top.equalTo(chipFrame.snp.top).offset(8)
+            $0.left.equalTo(chipFrame.snp.left).offset(12)
+            $0.bottom.equalTo(chipFrame.snp.bottom).offset(-8)
+            $0.right.equalTo(chipFrame.snp.right).offset(-12)
+        }
+        
+        descriptionBackground.snp.makeConstraints {
+            $0.width.equalTo(postImage.snp.width)
+            $0.bottom.equalTo(postImage.snp.bottom)
+        }
+        
+        postDescription.snp.makeConstraints {
+            $0.left.equalTo(descriptionBackground.snp.left).offset(16)
+            $0.right.equalTo(descriptionBackground.snp.right).offset(-16)
+            $0.bottom.equalTo(descriptionBackground.snp.bottom).offset(-12)
+            $0.top.equalTo(descriptionBackground.snp.top).offset(12)
+        }
+    }
+}

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -70,26 +70,24 @@ class HistoryCell: UICollectionViewCell {
     
     private func setupCell() {
         self.addSubview(postImage)
-        postImage.addSubview(chipFrame)
-        chipFrame.addSubview(chipLabel)
-        postImage.addSubview(descriptionBackground)
-        postImage.addSubview(postDescription)
-        
         postImage.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(UIScreen.main.bounds.width / 4 * 3)
         }
         
+        postImage.addSubview(chipFrame)
         chipFrame.snp.makeConstraints {
             $0.top.left.equalToSuperview().offset(8)
         }
         
+        chipFrame.addSubview(chipLabel)
         chipLabel.snp.makeConstraints {
             $0.verticalEdges.equalToSuperview().inset(8)
             $0.horizontalEdges.equalToSuperview().inset(12)
         }
         
+        postImage.addSubview(descriptionBackground)
         descriptionBackground.snp.makeConstraints {
             $0.bottom.width.equalToSuperview()
         }

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -76,34 +76,27 @@ class HistoryCell: UICollectionViewCell {
         postImage.addSubview(postDescription)
         
         postImage.snp.makeConstraints {
-            $0.top.equalTo(snp.top)
-            $0.left.equalTo(snp.left).offset(16)
-            $0.right.equalTo(snp.right).offset(-16)
+            $0.top.equalToSuperview()
+            $0.left.right.equalToSuperview().inset(16)
             $0.height.equalTo(UIScreen.main.bounds.width / 4 * 3)
         }
         
         chipFrame.snp.makeConstraints {
-            $0.topMargin.equalTo(8)
-            $0.leftMargin.equalTo(8)
+            $0.top.left.equalTo(8)
         }
         
         chipLabel.snp.makeConstraints {
-            $0.top.equalTo(chipFrame.snp.top).offset(8)
-            $0.left.equalTo(chipFrame.snp.left).offset(12)
-            $0.bottom.equalTo(chipFrame.snp.bottom).offset(-8)
-            $0.right.equalTo(chipFrame.snp.right).offset(-12)
+            $0.top.bottom.equalTo(chipFrame).inset(8)
+            $0.left.right.equalTo(chipFrame).inset(12)
         }
         
         descriptionBackground.snp.makeConstraints {
-            $0.width.equalTo(postImage.snp.width)
-            $0.bottom.equalTo(postImage.snp.bottom)
+            $0.bottom.width.equalToSuperview()
         }
         
         postDescription.snp.makeConstraints {
-            $0.left.equalTo(descriptionBackground.snp.left).offset(16)
-            $0.right.equalTo(descriptionBackground.snp.right).offset(-16)
-            $0.bottom.equalTo(descriptionBackground.snp.bottom).offset(-12)
-            $0.top.equalTo(descriptionBackground.snp.top).offset(12)
+            $0.top.bottom.equalTo(descriptionBackground).inset(12)
+            $0.left.right.equalTo(descriptionBackground).inset(16)
         }
     }
 }

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -16,11 +16,10 @@ class HistoryCell: UICollectionViewCell {
     // MARK: - View
     
     private let chipFrame: UIView = {
-        $0.backgroundColor = .white
+        $0.backgroundColor = UIColor(white: 1, alpha: 0.8)
         $0.layer.cornerRadius = 16
         $0.layer.borderColor = UIColor.black.cgColor
         $0.layer.borderWidth = 2
-        $0.layer.opacity = 0.8
         return $0
     }(UIView())
     
@@ -71,7 +70,7 @@ class HistoryCell: UICollectionViewCell {
     private func setupCell() {
         self.addSubview(postImage)
         postImage.addSubview(chipFrame)
-        postImage.addSubview(chipLabel)
+        chipFrame.addSubview(chipLabel)
         postImage.addSubview(descriptionBackground)
         postImage.addSubview(postDescription)
         
@@ -86,8 +85,8 @@ class HistoryCell: UICollectionViewCell {
         }
         
         chipLabel.snp.makeConstraints {
-            $0.top.bottom.equalTo(chipFrame).inset(8)
-            $0.left.right.equalTo(chipFrame).inset(12)
+            $0.verticalEdges.equalToSuperview().inset(8)
+            $0.horizontalEdges.equalToSuperview().inset(12)
         }
         
         descriptionBackground.snp.makeConstraints {

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 class HistoryCell: UICollectionViewCell {
     
     // MARK: - Property

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -82,7 +82,7 @@ class HistoryCell: UICollectionViewCell {
         }
         
         chipFrame.snp.makeConstraints {
-            $0.top.left.equalTo(8)
+            $0.top.left.equalToSuperview().offset(8)
         }
         
         chipLabel.snp.makeConstraints {

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -78,7 +78,7 @@ class HistoryCell: UICollectionViewCell {
         
         postImage.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.left.right.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(UIScreen.main.bounds.width / 4 * 3)
         }
         
@@ -96,8 +96,8 @@ class HistoryCell: UICollectionViewCell {
         }
         
         postDescription.snp.makeConstraints {
-            $0.top.bottom.equalTo(descriptionBackground).inset(12)
-            $0.left.right.equalTo(descriptionBackground).inset(16)
+            $0.verticalEdges.equalTo(descriptionBackground).inset(12)
+            $0.horizontalEdges.equalTo(descriptionBackground).inset(16)
         }
     }
 }

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -17,7 +17,7 @@ class PostDateCell: UICollectionViewCell {
     
     private let dateStack = UIView()
     
-    private let divider1: UIView = {
+    private let leftLineDot: UIView = {
         $0.backgroundColor = .gray
         return $0
     }(UIView())
@@ -30,7 +30,7 @@ class PostDateCell: UICollectionViewCell {
         return $0
     }(UILabel())
     
-    private let divider2: UIView = {
+    private let rightLineDot: UIView = {
         $0.backgroundColor = .gray
         return $0
     }(UIView())
@@ -51,15 +51,15 @@ class PostDateCell: UICollectionViewCell {
     
     private func setupCell() {
         self.addSubview(dateStack)
-        dateStack.addSubview(divider1)
+        dateStack.addSubview(leftLineDot)
         dateStack.addSubview(postingDate)
-        dateStack.addSubview(divider2)
+        dateStack.addSubview(rightLineDot)
         
         dateStack.snp.makeConstraints {
             $0.top.equalToSuperview().offset(16)
         }
         
-        divider1.snp.makeConstraints {
+        leftLineDot.snp.makeConstraints {
             $0.left.centerY.equalToSuperview()
             $0.right.equalTo(postingDate.snp.left)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
@@ -67,12 +67,12 @@ class PostDateCell: UICollectionViewCell {
         }
         
         postingDate.snp.makeConstraints {
-            $0.right.equalTo(divider2.snp.left)
+            $0.right.equalTo(rightLineDot.snp.left)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.centerY.equalToSuperview()
         }
         
-        divider2.snp.makeConstraints {
+        rightLineDot.snp.makeConstraints {
             $0.right.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -56,12 +56,11 @@ class PostDateCell: UICollectionViewCell {
         dateStack.addSubview(divider2)
         
         dateStack.snp.makeConstraints {
-            $0.top.equalTo(snp.top).offset(16)
+            $0.top.equalToSuperview().offset(16)
         }
         
         divider1.snp.makeConstraints {
-            $0.centerY.equalTo(dateStack.snp.centerY)
-            $0.left.equalTo(dateStack.snp.left)
+            $0.left.centerY.equalToSuperview()
             $0.right.equalTo(postingDate.snp.left)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
@@ -70,12 +69,11 @@ class PostDateCell: UICollectionViewCell {
         postingDate.snp.makeConstraints {
             $0.right.equalTo(divider2.snp.left)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
-            $0.centerY.equalTo(dateStack.snp.centerY)
+            $0.centerY.equalToSuperview()
         }
         
         divider2.snp.makeConstraints {
-            $0.centerY.equalTo(dateStack.snp.centerY)
-            $0.right.equalTo(dateStack.snp.right)
+            $0.right.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
         }

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -19,7 +19,7 @@ class PostDateCell: UICollectionViewCell {
     
     private let dateStack = UIView()
     
-    private let leftLineDash: UIView = {
+    private let leftDashLine: UIView = {
         $0.backgroundColor = .gray
         return $0
     }(UIView())
@@ -31,8 +31,8 @@ class PostDateCell: UICollectionViewCell {
         $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         return $0
     }(UILabel())
-    
-    private let rightLineDash: UIView = {
+     
+    private let rightDashLine: UIView = {
         $0.backgroundColor = .gray
         return $0
     }(UIView())
@@ -56,8 +56,8 @@ class PostDateCell: UICollectionViewCell {
             $0.top.equalToSuperview().offset(16)
         }
         
-        dateStack.addSubview(leftLineDash)
-        leftLineDash.snp.makeConstraints {
+        dateStack.addSubview(leftDashLine)
+        leftDashLine.snp.makeConstraints {
             $0.left.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
@@ -65,13 +65,13 @@ class PostDateCell: UICollectionViewCell {
         
         dateStack.addSubview(postingDate)
         postingDate.snp.makeConstraints {
-            $0.left.equalTo(leftLineDash.snp.right)
+            $0.left.equalTo(leftDashLine.snp.right)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.centerY.equalToSuperview()
         }
         
-        dateStack.addSubview(rightLineDash)
-        rightLineDash.snp.makeConstraints {
+        dateStack.addSubview(rightDashLine)
+        rightDashLine.snp.makeConstraints {
             $0.left.equalTo(postingDate.snp.right)
             $0.right.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -1,0 +1,83 @@
+//
+//  PostDateCell.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/18.
+//
+
+import UIKit
+
+class PostDateCell: UICollectionViewCell {
+    
+    // MARK: - Property
+    
+    static let identifier = "postDateCell"
+    
+    // MARK: - View
+    
+    private let dateStack = UIView()
+    
+    private let divider1: UIView = {
+        $0.backgroundColor = .gray
+        return $0
+    }(UIView())
+    
+    private let postingDate: UILabel = {
+        $0.text = "22.11.22"
+        $0.textColor = .black
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        return $0
+    }(UILabel())
+    
+    private let divider2: UIView = {
+        $0.backgroundColor = .gray
+        return $0
+    }(UIView())
+    
+    // MARK: - LifeCycle
+    
+    override private init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
+    
+    private func setupCell() {
+        self.addSubview(dateStack)
+        dateStack.addSubview(divider1)
+        dateStack.addSubview(postingDate)
+        dateStack.addSubview(divider2)
+        
+        dateStack.snp.makeConstraints {
+            $0.top.equalTo(snp.top).offset(16)
+        }
+        
+        divider1.snp.makeConstraints {
+            $0.centerY.equalTo(dateStack.snp.centerY)
+            $0.left.equalTo(dateStack.snp.left)
+            $0.right.equalTo(postingDate.snp.left)
+            $0.width.equalTo(UIScreen.main.bounds.width / 3)
+            $0.height.equalTo(1)
+        }
+        
+        postingDate.snp.makeConstraints {
+            $0.right.equalTo(divider2.snp.left)
+            $0.width.equalTo(UIScreen.main.bounds.width / 3)
+            $0.centerY.equalTo(dateStack.snp.centerY)
+        }
+        
+        divider2.snp.makeConstraints {
+            $0.centerY.equalTo(dateStack.snp.centerY)
+            $0.right.equalTo(dateStack.snp.right)
+            $0.width.equalTo(UIScreen.main.bounds.width / 3)
+            $0.height.equalTo(1)
+        }
+    }
+}

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 class PostDateCell: UICollectionViewCell {
     
     // MARK: - Property

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -19,7 +19,7 @@ class PostDateCell: UICollectionViewCell {
     
     private let dateStack = UIView()
     
-    private let leftLineDot: UIView = {
+    private let leftLineDash: UIView = {
         $0.backgroundColor = .gray
         return $0
     }(UIView())
@@ -32,7 +32,7 @@ class PostDateCell: UICollectionViewCell {
         return $0
     }(UILabel())
     
-    private let rightLineDot: UIView = {
+    private let rightLineDash: UIView = {
         $0.backgroundColor = .gray
         return $0
     }(UIView())
@@ -41,7 +41,6 @@ class PostDateCell: UICollectionViewCell {
     
     override private init(frame: CGRect) {
         super.init(frame: frame)
-
         setupCell()
     }
     
@@ -53,28 +52,27 @@ class PostDateCell: UICollectionViewCell {
     
     private func setupCell() {
         self.addSubview(dateStack)
-        dateStack.addSubview(leftLineDot)
-        dateStack.addSubview(postingDate)
-        dateStack.addSubview(rightLineDot)
-        
         dateStack.snp.makeConstraints {
             $0.top.equalToSuperview().offset(16)
         }
         
-        leftLineDot.snp.makeConstraints {
+        dateStack.addSubview(leftLineDash)
+        leftLineDash.snp.makeConstraints {
             $0.left.centerY.equalToSuperview()
-            $0.right.equalTo(postingDate.snp.left)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
         }
         
+        dateStack.addSubview(postingDate)
         postingDate.snp.makeConstraints {
-            $0.right.equalTo(rightLineDot.snp.left)
+            $0.left.equalTo(leftLineDash.snp.right)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.centerY.equalToSuperview()
         }
         
-        rightLineDot.snp.makeConstraints {
+        dateStack.addSubview(rightLineDash)
+        rightLineDash.snp.makeConstraints {
+            $0.left.equalTo(postingDate.snp.right)
             $0.right.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)

--- a/GiwazipClient/Cells/ProgressHeader.swift
+++ b/GiwazipClient/Cells/ProgressHeader.swift
@@ -37,9 +37,8 @@ class ProgressHeader: UICollectionReusableView {
     
     private func setupCell() {
         addSubview(progressBlock)
-        
         progressBlock.snp.makeConstraints {
-            $0.top.width.height.equalToSuperview()
+            $0.top.size.equalToSuperview()
         }
     }
 }

--- a/GiwazipClient/Cells/ProgressHeader.swift
+++ b/GiwazipClient/Cells/ProgressHeader.swift
@@ -37,9 +37,7 @@ class ProgressHeader: UICollectionReusableView {
         addSubview(progressBlock)
         
         progressBlock.snp.makeConstraints {
-            $0.top.equalTo(snp.top)
-            $0.width.equalTo(snp.width)
-            $0.height.equalTo(snp.height)
+            $0.top.width.height.equalToSuperview()
         }
     }
 }

--- a/GiwazipClient/Cells/ProgressHeader.swift
+++ b/GiwazipClient/Cells/ProgressHeader.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 class ProgressHeader: UICollectionReusableView {
 
     // MARK: - Property

--- a/GiwazipClient/Cells/ProgressHeader.swift
+++ b/GiwazipClient/Cells/ProgressHeader.swift
@@ -1,0 +1,45 @@
+//
+//  ProgressCell.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/18.
+//
+
+import UIKit
+
+class ProgressHeader: UICollectionReusableView {
+
+    // MARK: - Property
+    
+    static let identifier = "progressHeader"
+    
+    // MARK: - View
+    
+    private let progressBlock: UIView = {
+        $0.backgroundColor = .gray
+        return $0
+    }(UIView())
+    
+    // MARK: - LifeCycle
+    
+    override private init(frame: CGRect) {
+        super.init(frame: frame)
+        setupCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
+    
+    private func setupCell() {
+        addSubview(progressBlock)
+        
+        progressBlock.snp.makeConstraints {
+            $0.top.equalTo(snp.top)
+            $0.width.equalTo(snp.width)
+            $0.height.equalTo(snp.height)
+        }
+    }
+}

--- a/GiwazipClient/SceneDelegate.swift
+++ b/GiwazipClient/SceneDelegate.swift
@@ -23,19 +23,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window?.makeKeyAndVisible()
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-    }
 }

--- a/GiwazipClient/SceneDelegate.swift
+++ b/GiwazipClient/SceneDelegate.swift
@@ -25,30 +25,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -1,0 +1,67 @@
+//
+//  HistoryViewController.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/17.
+//
+
+import UIKit
+import SnapKit
+
+class HistoryViewController: UIViewController {
+    
+    private let titleView: UIView = {
+        return $0
+    }(UIView())
+    
+    private let titleName: UILabel = {
+        $0.text = "디너집"
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        $0.textAlignment = .center
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+    
+    private let titleDate: UILabel = {
+        $0.text = "22.11.11~23.01.13"
+        $0.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        $0.textAlignment = .center
+        $0.textColor = .gray
+        return $0
+    }(UILabel())
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        attribute()
+        layout()
+    }
+    
+    private func attribute() {
+        view.backgroundColor = .white
+        navigationItem.titleView = titleView
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "gearshape"),
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        navigationItem.rightBarButtonItem?.tintColor = .black
+    }
+    
+    private func layout() {
+        titleView.addSubview(titleName)
+        titleView.addSubview(titleDate)
+        
+        titleView.snp.makeConstraints {
+            $0.top.bottom.equalTo(self.navigationItem.titleView!)
+        }
+        titleName.snp.makeConstraints {
+            $0.top.left.right.equalTo(titleView)
+            $0.bottom.equalTo(titleDate.snp.top)
+        }
+        titleDate.snp.makeConstraints {
+            $0.bottom.left.right.equalTo(titleView)
+        }
+    }
+}

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -30,16 +30,42 @@ class HistoryViewController: UIViewController {
         return $0
     }(UILabel())
     
+    private let controlBar: UIView = {
+        $0.backgroundColor = .systemCyan
+        return $0
+    }(UIView())
+    
+    private let microCopy: UILabel = {
+        $0.text = "아직 진행 중인 시공이 없습니다."
+        $0.textColor = .gray
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        return $0
+    }(UILabel())
+    
+    let collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero,
+                                              collectionViewLayout: UICollectionViewFlowLayout())
+        return collectionView
+    }()
+    
+    // MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         attribute()
+        setupNavigationTitle()
         layout()
     }
     
+    // MARK: - Method
+    
     private func attribute() {
         view.backgroundColor = .white
-        navigationItem.titleView = titleView
+    private func setupNavigationTitle() {
+        navigationLayout()
+        
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             image: UIImage(systemName: "gearshape"),
             style: .plain,
@@ -49,19 +75,46 @@ class HistoryViewController: UIViewController {
         navigationItem.rightBarButtonItem?.tintColor = .black
     }
     
-    private func layout() {
+    private func navigationLayout() {
+        navigationItem.titleView = titleView
         titleView.addSubview(titleName)
         titleView.addSubview(titleDate)
-        
+
         titleView.snp.makeConstraints {
-            $0.top.bottom.equalTo(self.navigationItem.titleView!)
+            $0.height.equalTo(self.navigationItem.titleView!.snp.height)
         }
+
         titleName.snp.makeConstraints {
             $0.top.left.right.equalTo(titleView)
             $0.bottom.equalTo(titleDate.snp.top)
         }
+
         titleDate.snp.makeConstraints {
             $0.bottom.left.right.equalTo(titleView)
         }
     }
+    
+    private func layout() {
+        view.addSubview(controlBar)
+//        view.addSubview(microCopy)
+        view.addSubview(collectionView)
+
+        controlBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
+            $0.left.equalTo(16)
+            $0.right.equalTo(-16)
+            $0.height.equalTo(20)
+        }
+        
+//        microCopy.snp.makeConstraints {
+//            $0.center.equalTo(view.snp.center)
+//        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(controlBar.snp.bottom).offset(16)
+            $0.width.equalTo(view.snp.width)
+            $0.bottom.equalTo(view.snp.bottom)
+        }
+    }
+}
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class HistoryViewController: BaseViewController {
     
-    private let collectionView: UICollectionView = {
+    private let historyCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero,
                                               collectionViewLayout: UICollectionViewFlowLayout())
         return collectionView
@@ -34,21 +34,21 @@ class HistoryViewController: BaseViewController {
     override func attribute() {
         super.attribute()
         
-        collectionView.delegate = self
-        collectionView.dataSource = self
+        historyCollectionView.delegate = self
+        historyCollectionView.dataSource = self
         
-        collectionView.register(ProgressHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ProgressHeader.identifier)
-        collectionView.register(PostDateCell.self, forCellWithReuseIdentifier: PostDateCell.identifier)
-        collectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
+        historyCollectionView.register(ProgressHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ProgressHeader.identifier)
+        historyCollectionView.register(PostDateCell.self, forCellWithReuseIdentifier: PostDateCell.identifier)
+        historyCollectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
         
-        collectionView.showsVerticalScrollIndicator = false
+        historyCollectionView.showsVerticalScrollIndicator = false
     }
     
     override func layout() {
-        view.addSubview(collectionView)
+        view.addSubview(historyCollectionView)
         view.addSubview(microCopy)
         
-        collectionView.snp.makeConstraints {
+        historyCollectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
         

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -2,119 +2,90 @@
 //  HistoryViewController.swift
 //  GiwazipClient
 //
-//  Created by 지준용 on 2023/01/17.
+//  Created by 지준용 on 2023/01/18.
 //
 
 import UIKit
-import SnapKit
 
 class HistoryViewController: UIViewController {
     
-    private let titleView: UIView = {
-        return $0
-    }(UIView())
-    
-    private let titleName: UILabel = {
-        $0.text = "디너집"
-        $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
-        $0.textAlignment = .center
-        $0.textColor = .black
-        return $0
-    }(UILabel())
-    
-    private let titleDate: UILabel = {
-        $0.text = "22.11.11~23.01.13"
-        $0.font = UIFont.systemFont(ofSize: 14, weight: .regular)
-        $0.textAlignment = .center
-        $0.textColor = .gray
-        return $0
-    }(UILabel())
-    
-    private let controlBar: UIView = {
-        $0.backgroundColor = .systemCyan
-        return $0
-    }(UIView())
+    private let collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero,
+                                              collectionViewLayout: UICollectionViewFlowLayout())
+        return collectionView
+    }()
     
     private let microCopy: UILabel = {
         $0.text = "아직 진행 중인 시공이 없습니다."
         $0.textColor = .gray
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.isHidden = true
         return $0
     }(UILabel())
-    
-    let collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero,
-                                              collectionViewLayout: UICollectionViewFlowLayout())
-        return collectionView
-    }()
-    
-    // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         attribute()
-        setupNavigationTitle()
         layout()
     }
     
-    // MARK: - Method
-    
     private func attribute() {
-        view.backgroundColor = .white
-    private func setupNavigationTitle() {
-        navigationLayout()
+        collectionView.delegate = self
+        collectionView.dataSource = self
         
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: UIImage(systemName: "gearshape"),
-            style: .plain,
-            target: self,
-            action: nil
-        )
-        navigationItem.rightBarButtonItem?.tintColor = .black
-    }
-    
-    private func navigationLayout() {
-        navigationItem.titleView = titleView
-        titleView.addSubview(titleName)
-        titleView.addSubview(titleDate)
-
-        titleView.snp.makeConstraints {
-            $0.height.equalTo(self.navigationItem.titleView!.snp.height)
-        }
-
-        titleName.snp.makeConstraints {
-            $0.top.left.right.equalTo(titleView)
-            $0.bottom.equalTo(titleDate.snp.top)
-        }
-
-        titleDate.snp.makeConstraints {
-            $0.bottom.left.right.equalTo(titleView)
-        }
     }
     
     private func layout() {
-        view.addSubview(controlBar)
-//        view.addSubview(microCopy)
         view.addSubview(collectionView)
-
-        controlBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
-            $0.left.equalTo(16)
-            $0.right.equalTo(-16)
-            $0.height.equalTo(20)
-        }
-        
-//        microCopy.snp.makeConstraints {
-//            $0.center.equalTo(view.snp.center)
-//        }
+        view.addSubview(microCopy)
         
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(controlBar.snp.bottom).offset(16)
-            $0.width.equalTo(view.snp.width)
-            $0.bottom.equalTo(view.snp.bottom)
+            $0.top.left.bottom.right.equalTo(view)
+        }
+        
+        microCopy.snp.makeConstraints {
+            $0.center.equalTo(view.center)
         }
     }
+    
 }
+extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    
+    // MARK: - Section
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        // TODO: - 게시물 데이터 반영
+        return 5
+    }
+    
+    // MARK: - Header
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        return CGSize(width: UIScreen.main.bounds.width, height: 180)
+    }
+    
+    
+    // MARK: - Cell
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        var cell = UICollectionViewCell()
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if indexPath.row == 0 {
+            return CGSize(width: UIScreen.main.bounds.width, height: 20)
+        }
+        return CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width / 4 * 3)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 20
+    }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -24,13 +24,6 @@ class HistoryViewController: BaseViewController {
         return $0
     }(UILabel())
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        attribute()
-        layout()
-    }
-    
     override func attribute() {
         super.attribute()
         

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 class HistoryViewController: BaseViewController {
     
     private let historyCollectionView: UICollectionView = {

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -35,6 +35,7 @@ class HistoryViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dataSource = self
         
+        collectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
     }
     
     private func layout() {
@@ -75,6 +76,8 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         var cell = UICollectionViewCell()
+            cell = collectionView.dequeueReusableCell(withReuseIdentifier: HistoryCell.identifier, for: indexPath) as! HistoryCell
+            // TODO: - 게시물 데이터 반영
         return cell
     }
     

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -35,7 +35,10 @@ class HistoryViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dataSource = self
         
+        collectionView.register(PostDateCell.self, forCellWithReuseIdentifier: PostDateCell.identifier)
         collectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
+        
+        collectionView.showsVerticalScrollIndicator = false
     }
     
     private func layout() {
@@ -76,8 +79,14 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         var cell = UICollectionViewCell()
+        
+        if indexPath.row == 0 {
+            cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostDateCell.identifier, for: indexPath) as! PostDateCell
+            // TODO: - 날짜 데이터 반영
+        } else {
             cell = collectionView.dequeueReusableCell(withReuseIdentifier: HistoryCell.identifier, for: indexPath) as! HistoryCell
             // TODO: - 게시물 데이터 반영
+        }
         return cell
     }
     

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -35,6 +35,7 @@ class HistoryViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dataSource = self
         
+        collectionView.register(ProgressHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ProgressHeader.identifier)
         collectionView.register(PostDateCell.self, forCellWithReuseIdentifier: PostDateCell.identifier)
         collectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
         
@@ -74,6 +75,11 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
         return CGSize(width: UIScreen.main.bounds.width, height: 180)
     }
     
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ProgressHeader.identifier, for: indexPath) as! ProgressHeader
+        // TODO: - 진행률 반영
+        return header
+    }
     
     // MARK: - Cell
     

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HistoryViewController: UIViewController {
+class HistoryViewController: BaseViewController {
     
     private let collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero,
@@ -31,7 +31,9 @@ class HistoryViewController: UIViewController {
         layout()
     }
     
-    private func attribute() {
+    override func attribute() {
+        super.attribute()
+        
         collectionView.delegate = self
         collectionView.dataSource = self
         
@@ -42,20 +44,20 @@ class HistoryViewController: UIViewController {
         collectionView.showsVerticalScrollIndicator = false
     }
     
-    private func layout() {
+    override func layout() {
         view.addSubview(collectionView)
         view.addSubview(microCopy)
         
         collectionView.snp.makeConstraints {
-            $0.top.left.bottom.right.equalTo(view)
+            $0.edges.equalToSuperview()
         }
         
         microCopy.snp.makeConstraints {
-            $0.center.equalTo(view.center)
+            $0.center.equalToSuperview()
         }
     }
-    
 }
+
 extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
     // MARK: - Section

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -41,12 +41,11 @@ class HistoryViewController: BaseViewController {
     
     override func layout() {
         view.addSubview(historyCollectionView)
-        view.addSubview(microCopy)
-        
         historyCollectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
         
+        view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
         }

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -110,7 +110,6 @@ class SegmentViewController: BaseViewController {
         
         view.addSubview(segmentedControl)
         view.addSubview(pageContentView)
-        self.addChild(pageViewController)
         pageContentView.addSubview(pageViewController.view)
 
         segmentedControl.snp.makeConstraints {
@@ -128,7 +127,6 @@ class SegmentViewController: BaseViewController {
         pageViewController.view.snp.makeConstraints {
             $0.width.height.equalToSuperview()
         }
-        pageViewController.didMove(toParent: self)
     }
     
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+
 import SnapKit
 
 class SegmentViewController: UIViewController {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -15,7 +15,7 @@ class SegmentViewController: BaseViewController {
     
     private lazy var segmentedViewControllers: [UIViewController] = [workingView, inquiryView]
     
-    var currentViewNum: Int = 0 {
+    private var currentViewNum: Int = 0 {
         didSet {
             let direction: UIPageViewController.NavigationDirection = (oldValue <= currentViewNum ? .forward : .reverse)
             pageViewController.setViewControllers([segmentedViewControllers[currentViewNum]], direction: direction, animated: true)

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -88,20 +88,19 @@ class SegmentViewController: BaseViewController {
     
     private func navigationLayout() {
         self.navigationItem.titleView = titleView
-        titleView.addSubview(titleName)
-        titleView.addSubview(titleDate)
-
         titleView.snp.makeConstraints {
             $0.height.equalTo(navigationItem.titleView!.snp.height)
         }
-
+        
+        titleView.addSubview(titleName)
         titleName.snp.makeConstraints {
-            $0.top.left.right.equalToSuperview()
-            $0.bottom.equalTo(titleDate.snp.top)
+            $0.top.horizontalEdges.equalToSuperview()
         }
-
+        
+        titleView.addSubview(titleDate)
         titleDate.snp.makeConstraints {
-            $0.bottom.left.right.equalToSuperview()
+            $0.top.equalTo(titleName.snp.bottom)
+            $0.bottom.horizontalEdges.equalToSuperview()
         }
     }
     

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -1,0 +1,199 @@
+//
+//  SegmentViewController.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/17.
+//
+
+import UIKit
+import SnapKit
+
+class SegmentViewController: UIViewController {
+    
+    // MARK: - Property
+    
+    private lazy var segmentedViewControllers: [UIViewController] = [workingView, inquiryView]
+    
+    var currentViewNum: Int = 0 {
+        didSet {
+            let direction: UIPageViewController.NavigationDirection = (oldValue <= currentViewNum ? .forward : .reverse)
+            pageViewController.setViewControllers([segmentedViewControllers[currentViewNum]], direction: direction, animated: true)
+        }
+    }
+    
+    // MARK: - View
+    
+    private let titleView = UIView()
+    
+    private let titleName: UILabel = {
+        $0.text = "디너집"
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        $0.textAlignment = .center
+        $0.textColor = .black
+        return $0
+    }(UILabel())
+    
+    private let titleDate: UILabel = {
+        $0.text = "22.11.11~23.01.13"
+        $0.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        $0.textAlignment = .center
+        $0.textColor = .gray
+        return $0
+    }(UILabel())
+    
+    private let segmentedControl = UISegmentedControl(items: ["시공내역", "문의내역"])
+    
+    private let workingView: HistoryViewController = {
+        // TODO: - 추후 데이터 추가
+        return $0
+    }(HistoryViewController())
+    
+    private let inquiryView: HistoryViewController = {
+        // TODO: - 추후 데이터 추가
+        return $0
+    }(HistoryViewController())
+    
+    private let pageContentView = UIView()
+    
+    private lazy var pageViewController: UIPageViewController = {
+        $0.setViewControllers([segmentedViewControllers[0]],
+                              direction: .forward,
+                              animated: true)
+        return $0
+    }(UIPageViewController(transitionStyle: .scroll,
+                           navigationOrientation: .horizontal))
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        attribute()
+        setupNavigationTitle()
+        layout()
+        setupSegmentedControl()
+    }
+    
+    // MARK: - Method
+    
+    private func attribute() {
+        view.backgroundColor = .white
+        
+        pageViewController.delegate = self
+        pageViewController.dataSource = self
+    }
+    
+    private func setupNavigationTitle() {
+        navigationLayout()
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "gearshape"),
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        navigationItem.rightBarButtonItem?.tintColor = .black
+    }
+    
+    private func navigationLayout() {
+        self.navigationItem.titleView = titleView
+        titleView.addSubview(titleName)
+        titleView.addSubview(titleDate)
+
+        titleView.snp.makeConstraints {
+            $0.height.equalTo(self.navigationItem.titleView!.snp.height)
+        }
+
+        titleName.snp.makeConstraints {
+            $0.top.left.right.equalTo(titleView)
+            $0.bottom.equalTo(titleDate.snp.top)
+        }
+
+        titleDate.snp.makeConstraints {
+            $0.bottom.left.right.equalTo(titleView)
+        }
+    }
+    
+    private func layout() {
+        view.addSubview(segmentedControl)
+        view.addSubview(pageContentView)
+        self.addChild(pageViewController)
+        pageContentView.addSubview(pageViewController.view)
+
+        segmentedControl.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
+            $0.bottom.equalTo(pageContentView.snp.top).offset(-12)
+            $0.left.equalTo(view.safeAreaLayoutGuide.snp.left).offset(16)
+            $0.width.equalTo(180)
+            $0.height.equalTo(20)
+        }
+        
+        pageContentView.snp.makeConstraints {
+            $0.width.equalTo(view.snp.width)
+            $0.bottom.equalTo(view.snp.bottom)
+        }
+        
+        pageViewController.view.snp.makeConstraints {
+            $0.width.equalTo(pageContentView.snp.width)
+            $0.height.equalTo(pageContentView.snp.height)
+        }
+        pageViewController.didMove(toParent: self)
+    }
+    
+    private func setupSegmentedControl() {
+        segmentedControl.setTitleTextAttributes(
+            [NSAttributedString.Key
+                .foregroundColor: UIColor.gray,
+                .font: UIFont.systemFont(ofSize: 20, weight: .bold)], for: .normal)
+        segmentedControl.setTitleTextAttributes(
+            [NSAttributedString.Key
+                .foregroundColor: UIColor.black,
+                .font: UIFont.systemFont(ofSize: 20, weight: .bold)], for: .selected)
+        
+        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.addTarget(self, action: #selector(selectedSegmentControl), for: .valueChanged)
+        
+        removeSegmentDefaultConfigure()
+        selectedSegmentControl(control: segmentedControl)
+    }
+    
+    private func removeSegmentDefaultConfigure() {
+        let image = UIImage()
+        
+        segmentedControl.setBackgroundImage(image,
+                                            for: .normal,
+                                            barMetrics: .default)
+        segmentedControl.setBackgroundImage(image,
+                                            for: .selected,
+                                            barMetrics: .default)
+        segmentedControl.setDividerImage(image,
+                                         forLeftSegmentState: .selected,
+                                         rightSegmentState: .normal,
+                                         barMetrics: .default)
+    }
+    
+    @objc func selectedSegmentControl(control: UISegmentedControl) {
+        currentViewNum = control.selectedSegmentIndex
+    }
+}
+
+extension SegmentViewController: UIPageViewControllerDelegate, UIPageViewControllerDataSource {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let index = segmentedViewControllers.firstIndex(of: viewController), index == 1 else { return nil }
+        return segmentedViewControllers[0]
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let index = segmentedViewControllers.firstIndex(of: viewController), index == 0 else { return nil }
+        return segmentedViewControllers[1]
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        
+        guard let vc = pageViewController.viewControllers?[0],
+              let index = segmentedViewControllers.firstIndex(of: vc) else { return }
+        
+        currentViewNum = index
+        segmentedControl.selectedSegmentIndex = index
+    }
+}

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -64,21 +64,14 @@ class SegmentViewController: BaseViewController {
     }(UIPageViewController(transitionStyle: .scroll,
                            navigationOrientation: .horizontal))
     
-    // MARK: - LifeCycle
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        attribute()
-        setupNavigationTitle()
-        layout()
-        setupSegmentedControl()
-    }
-    
     // MARK: - Method
     
     override func attribute() {
         super.attribute()
+        
+        setupNavigationTitle()
+        setupSegmentedControl()
+        
         pageViewController.delegate = self
         pageViewController.dataSource = self
     }

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class SegmentViewController: UIViewController {
+class SegmentViewController: BaseViewController {
     
     // MARK: - Property
     
@@ -68,7 +68,7 @@ class SegmentViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         attribute()
         setupNavigationTitle()
         layout()
@@ -77,16 +77,13 @@ class SegmentViewController: UIViewController {
     
     // MARK: - Method
     
-    private func attribute() {
-        view.backgroundColor = .white
-        
+    override func attribute() {
+        super.attribute()
         pageViewController.delegate = self
         pageViewController.dataSource = self
     }
     
     private func setupNavigationTitle() {
-        navigationLayout()
-        
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             image: UIImage(systemName: "gearshape"),
             style: .plain,
@@ -102,20 +99,22 @@ class SegmentViewController: UIViewController {
         titleView.addSubview(titleDate)
 
         titleView.snp.makeConstraints {
-            $0.height.equalTo(self.navigationItem.titleView!.snp.height)
+            $0.height.equalTo(navigationItem.titleView!.snp.height)
         }
 
         titleName.snp.makeConstraints {
-            $0.top.left.right.equalTo(titleView)
+            $0.top.left.right.equalToSuperview()
             $0.bottom.equalTo(titleDate.snp.top)
         }
 
         titleDate.snp.makeConstraints {
-            $0.bottom.left.right.equalTo(titleView)
+            $0.bottom.left.right.equalToSuperview()
         }
     }
     
-    private func layout() {
+    override func layout() {
+        navigationLayout()
+        
         view.addSubview(segmentedControl)
         view.addSubview(pageContentView)
         self.addChild(pageViewController)
@@ -124,19 +123,17 @@ class SegmentViewController: UIViewController {
         segmentedControl.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
             $0.bottom.equalTo(pageContentView.snp.top).offset(-12)
-            $0.left.equalTo(view.safeAreaLayoutGuide.snp.left).offset(16)
+            $0.left.equalToSuperview().offset(16)
             $0.width.equalTo(180)
             $0.height.equalTo(20)
         }
         
         pageContentView.snp.makeConstraints {
-            $0.width.equalTo(view.snp.width)
-            $0.bottom.equalTo(view.snp.bottom)
+            $0.bottom.width.equalToSuperview()
         }
         
         pageViewController.view.snp.makeConstraints {
-            $0.width.equalTo(pageContentView.snp.width)
-            $0.height.equalTo(pageContentView.snp.height)
+            $0.width.height.equalToSuperview()
         }
         pageViewController.didMove(toParent: self)
     }
@@ -155,12 +152,11 @@ class SegmentViewController: UIViewController {
         segmentedControl.addTarget(self, action: #selector(selectedSegmentControl), for: .valueChanged)
         
         removeSegmentDefaultConfigure()
-        selectedSegmentControl(control: segmentedControl)
     }
     
     private func removeSegmentDefaultConfigure() {
         let image = UIImage()
-        
+
         segmentedControl.setBackgroundImage(image,
                                             for: .normal,
                                             barMetrics: .default)
@@ -190,10 +186,10 @@ extension SegmentViewController: UIPageViewControllerDelegate, UIPageViewControl
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        
+
         guard let vc = pageViewController.viewControllers?[0],
               let index = segmentedViewControllers.firstIndex(of: vc) else { return }
-        
+
         currentViewNum = index
         segmentedControl.selectedSegmentIndex = index
     }

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -125,7 +125,7 @@ class SegmentViewController: BaseViewController {
         }
         
         pageViewController.view.snp.makeConstraints {
-            $0.width.height.equalToSuperview()
+            $0.size.equalToSuperview()
         }
     }
     


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- HistoryView Layout 코드를 분할하여 올리기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
 - 네비게이션 구성
   - [x] 방 이름(아파트 이름)
   - [x] 계약기간 표시 (네비게이션 타이틀 2줄)
   - [x] 환경설정 버튼 추가
- 시공내역 문의내역 화면
  - [x] 게시물 셀이 보여지는 부분 스크롤
  - [x] 게시물이 없을 때, 마이크로카피

## ToDo 📆 (남은 작업)
- 탭 구성
  - [x] 시공내역 / 문의내역 탭 추가
- 날짜 구분선
  - [x] 날짜와 선으로 날짜 구분 표시
- 게시물 셀
  - [x] 비율 - 4:3
  - [x] 게시물 하단 게시글 칸 구분 (opacity 0.7, 글자색 - White)
  - [x] 시공내역에서 좌상단 카테고리 칩 표시

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/98405970/213247520-89945f5b-468e-4e79-99f8-61c5d95dfeea.png" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 코드가 길어져서 게시물부분은 제외하고 올렸습니다만 미뉴의 요청으로 추가하여 좀 길어졌습니다. 양해바랍니다 ^^