### PR TITLE
[Design] 문의내역 작성하기(사진) 레이아웃

### DIFF
--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63E929711307004034AD /* BaseCoordinator.swift */; };
 		260A63F22975E01F004034AD /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63F12975E01F004034AD /* SplashViewController.swift */; };
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
+		98419D74297C0554005E0EF6 /* PostingPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
 		988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D7297777E500018F07 /* ProgressHeader.swift */; };
@@ -50,6 +51,7 @@
 		260A63F12975E01F004034AD /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		438BF0422977CA28005E4CF3 /* EnterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
+		98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPhotoViewController.swift; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
 		988C56D32976D3BA00018F07 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
 		988C56D7297777E500018F07 /* ProgressHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHeader.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				438BF0422977CA28005E4CF3 /* EnterViewController.swift */,
 				988C56CF29768F2D00018F07 /* SegmentViewController.swift */,
 				988C56DB2978349D00018F07 /* HistoryViewController.swift */,
+				98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -329,6 +332,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98419D74297C0554005E0EF6 /* PostingPhotoViewController.swift in Sources */,
 				260A63E029710834004034AD /* AppCoordinator.swift in Sources */,
 				260A63D429710784004034AD /* ViewModel.swift in Sources */,
 				260A63DE297107E4004034AD /* Extension+.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		260A63F22975E01F004034AD /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260A63F12975E01F004034AD /* SplashViewController.swift */; };
 		438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438BF0422977CA28005E4CF3 /* EnterViewController.swift */; };
 		98419D74297C0554005E0EF6 /* PostingPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */; };
+		98419D76297C1BF9005E0EF6 /* PostingPhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98419D75297C1BF9005E0EF6 /* PostingPhotoCell.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
 		988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D7297777E500018F07 /* ProgressHeader.swift */; };
@@ -52,6 +53,7 @@
 		438BF0422977CA28005E4CF3 /* EnterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnterViewController.swift; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
 		98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPhotoViewController.swift; sourceTree = "<group>"; };
+		98419D75297C1BF9005E0EF6 /* PostingPhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPhotoCell.swift; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
 		988C56D32976D3BA00018F07 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
 		988C56D7297777E500018F07 /* ProgressHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHeader.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				988C56D7297777E500018F07 /* ProgressHeader.swift */,
 				988C56D929779D2A00018F07 /* PostDateCell.swift */,
 				988C56D32976D3BA00018F07 /* HistoryCell.swift */,
+				98419D75297C1BF9005E0EF6 /* PostingPhotoCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -345,6 +348,7 @@
 				260A63D8297107AA004034AD /* Cell.swift in Sources */,
 				260A63E629710A5C004034AD /* SubViewController.swift in Sources */,
 				260A63E229710846004034AD /* MainCoordinator.swift in Sources */,
+				98419D76297C1BF9005E0EF6 /* PostingPhotoCell.swift in Sources */,
 				260A63E829710A7F004034AD /* SubCoordinator.swift in Sources */,
 				260A63F22975E01F004034AD /* SplashViewController.swift in Sources */,
 				260A63EA29711307004034AD /* BaseCoordinator.swift in Sources */,

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -1,0 +1,48 @@
+//
+//  PostingPhotoCell.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/21.
+//
+
+import UIKit
+
+import SnapKit
+
+class PostingPhotoCell: UICollectionViewCell {
+
+    // MARK: - Property
+
+    static let identifier = "postingPhotoCell"
+
+    // MARK: - View
+    
+    let postingImage: UIImageView = {
+        $0.backgroundColor = .gray
+        $0.image = UIImage(systemName: "gearshape")
+        $0.layer.cornerRadius = 16
+        return $0
+    }(UIImageView())
+    
+    // MARK: - LifeCycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        attribute()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
+    
+    private func layout() {
+        self.addSubview(postingImage)
+        postingImage.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+        }
+    }
+}

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -28,8 +28,7 @@ class PostingPhotoCell: UICollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        attribute()
-        layout()
+        setupCell()
     }
     
     required init?(coder: NSCoder) {
@@ -38,11 +37,10 @@ class PostingPhotoCell: UICollectionViewCell {
     
     // MARK: - Method
     
-    private func layout() {
+    private func setupCell() {
         self.addSubview(postingImage)
         postingImage.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -13,7 +13,7 @@ class PostingPhotoViewController: BaseViewController {
     
     // MARK: - View
     
-    private let guidancePhrase: UILabel = {
+    private let guidanceLabel: UILabel = {
         $0.text = """
                   문의할 사진을 추가해주세요.
                   (최대 5장까지 선택 가능합니다.)
@@ -52,15 +52,15 @@ class PostingPhotoViewController: BaseViewController {
     override func layout() {
         super.layout()
         
-        view.addSubview(guidancePhrase)
-        guidancePhrase.snp.makeConstraints {
+        view.addSubview(guidanceLabel)
+        guidanceLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
             $0.centerX.equalToSuperview()
         }
         
         view.addSubview(photoCollectionView)
         photoCollectionView.snp.makeConstraints {
-            $0.top.equalTo(guidancePhrase.snp.bottom).offset(16)
+            $0.top.equalTo(guidanceLabel.snp.bottom).offset(16)
             $0.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -1,0 +1,100 @@
+//
+//  PostingPhotoViewController.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/01/21.
+//
+
+import UIKit
+
+import SnapKit
+
+class PostingPhotoViewController: BaseViewController {
+    
+    // MARK: - View
+    
+    private let guidancePhrase: UILabel = {
+        $0.text = """
+                  문의할 사진을 추가해주세요.
+                  (최대 5장까지 선택 가능합니다.)
+                  """
+        $0.textColor = .gray
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        $0.numberOfLines = 2
+        return $0
+    }(UILabel())
+    
+    private let photoCollectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero,
+                                              collectionViewLayout: UICollectionViewFlowLayout())
+        return collectionView
+    }()
+    
+    private let nextButton: UIButton = {
+        $0.setTitle("다음", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .blue
+        $0.layer.cornerRadius = 16
+        return $0
+    }(UIButton())
+    
+    // MARK: - Method
+    
+    override func attribute() {
+        super.attribute()
+        
+        photoCollectionView.delegate = self
+        photoCollectionView.dataSource = self
+        photoCollectionView.register(PostingPhotoCell.self, forCellWithReuseIdentifier: PostingPhotoCell.identifier)
+    }
+    
+    override func layout() {
+        super.layout()
+        
+        view.addSubview(guidancePhrase)
+        guidancePhrase.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
+            $0.centerX.equalToSuperview()
+        }
+        
+        view.addSubview(photoCollectionView)
+        photoCollectionView.snp.makeConstraints {
+            $0.top.equalTo(guidancePhrase.snp.bottom).offset(16)
+            $0.bottom.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        view.addSubview(nextButton)
+        nextButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+            $0.height.equalTo(50)
+        }
+    }
+}
+
+extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        // TODO: - 이미지 갯수
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingPhotoCell.identifier, for: indexPath) as! PostingPhotoCell
+        
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        let width = UIScreen.main.bounds.width - 32
+        let height = width / 4 * 3
+        
+        return CGSize(width: width, height: height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 20
+    }
+}


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 문의내역 작성뷰 중 사진관련 레이아웃 추가히가 위함

## Key Changes 🔥 (주요 구현/변경 사항)
  - [ ] 사진 업로드 셀 보여주기
  - [ ] 사진 셀 최대 5개까지 보여주기
  - [ ] 다음 버튼

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
<Img src = "https://user-images.githubusercontent.com/98405970/213916944-744afb0f-4722-490a-a8ae-4c0b869cf73c.png" width = "300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 코드입니다. 가볍게 확인해주시면 되겠습니다.

## Close Issues 🔒 (닫을 Issue)
Close #20.
