### PR TITLE
[Feature] 문의내역 사진 업로드 셀 기능 추가

### DIFF
--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -5,6 +5,7 @@
 //  Created by 지준용 on 2023/01/21.
 //
 
+import PhotosUI
 import UIKit
 
 import SnapKit
@@ -19,8 +20,16 @@ class PostingPhotoCell: UICollectionViewCell {
     
     let postingImage: UIImageView = {
         $0.backgroundColor = .gray
-        $0.image = UIImage(systemName: "gearshape")
+        $0.contentMode = .scaleAspectFill
+        $0.tintColor = .white
+        $0.clipsToBounds = true
         $0.layer.cornerRadius = 16
+        return $0
+    }(UIImageView())
+    
+    let plusIcon: UIImageView = {
+        $0.image = UIImage(systemName: "plus")
+        $0.tintColor = .white
         return $0
     }(UIImageView())
     
@@ -41,6 +50,12 @@ class PostingPhotoCell: UICollectionViewCell {
         self.addSubview(postingImage)
         postingImage.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        postingImage.addSubview(plusIcon)
+        plusIcon.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalTo(50)
         }
     }
 }

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -35,7 +35,7 @@ class PostingPhotoCell: UICollectionViewCell {
     
     // MARK: - LifeCycle
 
-    override init(frame: CGRect) {
+    override private init(frame: CGRect) {
         super.init(frame: frame)
         setupCell()
     }

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -5,7 +5,6 @@
 //  Created by 지준용 on 2023/01/21.
 //
 
-import PhotosUI
 import UIKit
 
 import SnapKit

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -18,7 +18,7 @@ class PostingPhotoCell: UICollectionViewCell {
     // MARK: - View
     
     let postingImage: UIImageView = {
-        $0.backgroundColor = .gray
+        $0.backgroundColor = .systemGray4
         $0.contentMode = .scaleAspectFill
         $0.tintColor = .white
         $0.clipsToBounds = true

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -5,6 +5,7 @@
 //  Created by 지준용 on 2023/01/21.
 //
 
+import PhotosUI
 import UIKit
 
 import SnapKit

--- a/GiwazipClient/Extensions+/Alert+.swift
+++ b/GiwazipClient/Extensions+/Alert+.swift
@@ -40,15 +40,14 @@ extension UIViewController {
         self.present(alertViewController, animated: true, completion: completion)
     }
     
-    func makeActionSheet(title: String? = "",
+    func makeActionSheet(title: String? = nil,
                          message: String? = nil,
-                         firstContext: String? = nil,
-                         secondContext: String? = nil,
+                         firstContext: String? = "",
+                         secondContext: String? = "",
                          cancelContext: String? = "취소",
                          didTapFirst: ((UIAlertAction) -> Void)? = nil,
                          didTapSecond: ((UIAlertAction) -> Void)? = nil,
-                         didTapCancel: ((UIAlertAction) -> Void)? = nil,
-                         completion: (() -> Void)? = nil) {
+                         didTapCancel: ((UIAlertAction) -> Void)? = nil) {
         
         let actionSheet = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
         let firstAction = UIAlertAction(title: firstContext, style: .default, handler: didTapFirst)

--- a/GiwazipClient/Extensions+/Alert+.swift
+++ b/GiwazipClient/Extensions+/Alert+.swift
@@ -39,4 +39,25 @@ extension UIViewController {
         
         self.present(alertViewController, animated: true, completion: completion)
     }
+    
+    func makeActionSheet(title: String? = nil,
+                         message: String? = nil,
+                         firstContext: String? = nil,
+                         secondContext: String? = nil,
+                         cancelContext: String? = "취소",
+                         didTapFirst: ((UIAlertAction) -> Void)? = nil,
+                         didTapSecond: ((UIAlertAction) -> Void)? = nil,
+                         didTapCancel: ((UIAlertAction) -> Void)? = nil,
+                         completion : (() -> Void)? = nil) {
+        
+        let actionSheet = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
+        let firstAction = UIAlertAction(title: firstContext, style: .default, handler: didTapFirst)
+        let secondAction = UIAlertAction(title: secondContext, style: .destructive, handler: didTapSecond)
+        let cancelAction = UIAlertAction(title: cancelContext, style: .cancel, handler: didTapCancel)
+        actionSheet.addAction(firstAction)
+        actionSheet.addAction(secondAction)
+        actionSheet.addAction(cancelAction)
+        
+        present(actionSheet, animated: true)
+    }
 }

--- a/GiwazipClient/Extensions+/Alert+.swift
+++ b/GiwazipClient/Extensions+/Alert+.swift
@@ -40,7 +40,7 @@ extension UIViewController {
         self.present(alertViewController, animated: true, completion: completion)
     }
     
-    func makeActionSheet(title: String? = nil,
+    func makeActionSheet(title: String? = "",
                          message: String? = nil,
                          firstContext: String? = "",
                          secondContext: String? = "",

--- a/GiwazipClient/Extensions+/Alert+.swift
+++ b/GiwazipClient/Extensions+/Alert+.swift
@@ -9,10 +9,10 @@ import UIKit
 
 extension UIViewController {
     
-    func makeAlert(title: String? = nil,
+    func makeAlert(title: String? = "",
                    message: String? = nil,
                    okAction: ((UIAlertAction) -> Void)? = nil,
-                   completion : (() -> Void)? = nil) {
+                   completion: (() -> Void)? = nil) {
         let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         let okAction = UIAlertAction(title: "확인", style: .default, handler: okAction)
@@ -21,13 +21,13 @@ extension UIViewController {
         self.present(alertViewController, animated: true, completion: completion)
     }
     
-    func makeAlert(title: String? = nil,
-                          message: String? = nil,
-                          okTitle: String = "확인",
-                          cancelTitle: String = "취소",
-                          okAction: ((UIAlertAction) -> Void)?,
-                          cancelAction: ((UIAlertAction) -> Void)? = nil,
-                          completion : (() -> Void)? = nil) {
+    func makeAlert(title: String? = "",
+                   message: String? = nil,
+                   okTitle: String = "확인",
+                   cancelTitle: String = "취소",
+                   okAction: ((UIAlertAction) -> Void)?,
+                   cancelAction: ((UIAlertAction) -> Void)? = nil,
+                   completion: (() -> Void)? = nil) {
         
         let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
@@ -40,7 +40,7 @@ extension UIViewController {
         self.present(alertViewController, animated: true, completion: completion)
     }
     
-    func makeActionSheet(title: String? = nil,
+    func makeActionSheet(title: String? = "",
                          message: String? = nil,
                          firstContext: String? = nil,
                          secondContext: String? = nil,
@@ -48,7 +48,7 @@ extension UIViewController {
                          didTapFirst: ((UIAlertAction) -> Void)? = nil,
                          didTapSecond: ((UIAlertAction) -> Void)? = nil,
                          didTapCancel: ((UIAlertAction) -> Void)? = nil,
-                         completion : (() -> Void)? = nil) {
+                         completion: (() -> Void)? = nil) {
         
         let actionSheet = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
         let firstAction = UIAlertAction(title: firstContext, style: .default, handler: didTapFirst)

--- a/GiwazipClient/Extensions+/Alert+.swift
+++ b/GiwazipClient/Extensions+/Alert+.swift
@@ -40,7 +40,7 @@ extension UIViewController {
         self.present(alertViewController, animated: true, completion: completion)
     }
     
-    func makeActionSheet(title: String? = "",
+    func makeActionSheet(title: String? = nil,
                          message: String? = nil,
                          firstContext: String? = "",
                          secondContext: String? = "",

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -16,7 +16,7 @@ class PostingPhotoViewController: BaseViewController {
 
     private var uiButtonConfiguration = UIButton.Configuration.plain()
     private var pickerConfiguration = PHPickerConfiguration()
-    private var isChangedCondition = false
+    private var isChangedPHPickerRole = false
     private var selectedIndex = 0
     private let emptyImage = UIImage()
 
@@ -162,14 +162,14 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
         setupPHPickerConfigure()
 
         if (selectedIndex == 0) && (images[0] == emptyImage) {
-            isChangedCondition = true
+            isChangedPHPickerRole = true
             showPHPicker()
         } else {
             makeActionSheet(
                 firstContext: "사진 변경하기",
                 secondContext: "사진 삭제하기",
                 didTapFirst: { change in
-                    self.isChangedCondition = false
+                    self.isChangedPHPickerRole = false
                     self.didTapChangeAction()
                 },
                 didTapSecond: { delete in
@@ -197,7 +197,7 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
                         
-                        if self.isChangedCondition {
+                        if self.isChangedPHPickerRole {
                             self.images.insert(image, at: self.selectedIndex + 1)
                         } else {
                             self.images[self.selectedIndex] = image

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -190,13 +190,13 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
 extension PostingPhotoViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
 
-        picker.dismiss(animated: true)
+        dismiss(animated: true)
 
         let itemProviders = results.map { $0.itemProvider }
 
         for item in itemProviders {
             if item.canLoadObject(ofClass: UIImage.self) {
-                item.loadObject(ofClass: UIImage.self) { (image, error) in
+                item.loadObject(ofClass: UIImage.self) { (image, _) in
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
                         self.images.insert(image,

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -138,16 +138,14 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
 
         cell.plusIcon.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
 
-        if (images.count == 6) && (images[0] == emptyImage) {
+        if images.count == 6 {
             images.remove(at: 0)
+            photoCollectionView.reloadData()
+        } else if images.count < 5 && !images.contains(emptyImage) {
+            images.insert(emptyImage, at: 0)
             photoCollectionView.reloadData()
         } else {
             cell.postingImage.image = self.images[indexPath.item]
-
-            if images.count < 5 && !images.contains(emptyImage) {
-                images.insert(emptyImage, at: 0)
-                photoCollectionView.reloadData()
-            }
         }
         return cell
     }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -15,7 +15,7 @@ class PostingPhotoViewController: BaseViewController {
     // MARK: - Property
 
     private var uiButtonConfiguration = UIButton.Configuration.plain()
-    private var configuration = PHPickerConfiguration()
+    private var pickerConfiguration = PHPickerConfiguration()
     private var isChangedConfigure = false
     private var selectedIndex = 0
     private let emptyImage = UIImage()
@@ -111,23 +111,25 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     private func setupPHPickerConfigure() {
-        configuration.selection = .ordered
-        configuration.selectionLimit = (6 - images.count)
-        configuration.filter = .any(of: [.images, .not(.livePhotos)])
+        pickerConfiguration.selection = .ordered
+        pickerConfiguration.selectionLimit = (6 - images.count)
+        pickerConfiguration.filter = .any(of: [.images, .not(.livePhotos)])
     }
 
     private func showPHPicker() {
-        let picker = PHPickerViewController(configuration: configuration)
+        let picker = PHPickerViewController(configuration: pickerConfiguration)
         picker.delegate = self
         present(picker, animated: true)
     }
+        pickerConfiguration.selectionLimit = 1
+        pickerConfiguration.selection = .default
 }
 
 extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return images.count
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingPhotoCell.identifier, for: indexPath) as! PostingPhotoCell
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -22,14 +22,7 @@ class PostingPhotoViewController: BaseViewController {
 
     private lazy var images: [UIImage] = [emptyImage] {
         didSet {
-            if images.count > 1 {
-                // TODO: - 네비게이션 기능 필요.
-                nextButton.backgroundColor = .blue
-                nextButton.isEnabled = true
-            } else {
-                nextButton.backgroundColor = .systemGray4
-                nextButton.isEnabled = false
-            }
+            nextButton.isEnabled = (images.count) > 1 ? true : false
         }
     }
 
@@ -50,7 +43,7 @@ class PostingPhotoViewController: BaseViewController {
     private let photoCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero,
                                               collectionViewLayout: UICollectionViewFlowLayout())
-        collectionView.contentInset.bottom = 80
+        collectionView.contentInset.bottom = 20
         return collectionView
     }()
 
@@ -58,8 +51,9 @@ class PostingPhotoViewController: BaseViewController {
         $0.configuration?.title = "다음"
         $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.configuration?.baseForegroundColor = .white
+        $0.configuration?.baseBackgroundColor = .blue
+        $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
-        $0.backgroundColor = .systemGray4
         $0.isEnabled = false
         return $0
     }(UIButton(configuration: buttonConfiguration))
@@ -91,12 +85,12 @@ class PostingPhotoViewController: BaseViewController {
         view.addSubview(photoCollectionView)
         photoCollectionView.snp.makeConstraints {
             $0.top.equalTo(guidanceLabel.snp.bottom).offset(16)
-            $0.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
 
         view.addSubview(nextButton)
         nextButton.snp.makeConstraints {
+            $0.top.equalTo(photoCollectionView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
             $0.height.equalTo(90)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -103,6 +103,13 @@ class PostingPhotoViewController: BaseViewController {
         }
     }
 
+    @objc func showAlert() {
+        let alert = UIAlertController(title: nil, message: "사진을 한 장 이상 선택해야 합니다.", preferredStyle: .alert)
+        let check = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(check)
+        present(alert, animated: true)
+    }
+
     func setupPHPickerConfigure() {
         configuration.selection = .ordered
         configuration.selectionLimit = (6 - images.count)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -5,15 +5,18 @@
 //  Created by 지준용 on 2023/01/21.
 //
 
+import PhotosUI
 import UIKit
 
 import SnapKit
 
 class PostingPhotoViewController: BaseViewController {
-    
+
+    // MARK: - Property
+
     private var uiButtonConfiguration = UIButton.Configuration.plain()
     // MARK: - View
-    
+
     private let guidanceLabel: UILabel = {
         $0.text = """
                   문의할 사진을 추가해주세요.
@@ -25,10 +28,11 @@ class PostingPhotoViewController: BaseViewController {
         $0.numberOfLines = 2
         return $0
     }(UILabel())
-    
+
     private let photoCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero,
                                               collectionViewLayout: UICollectionViewFlowLayout())
+        collectionView.contentInset.bottom = 80
         return collectionView
     }()
 
@@ -80,6 +84,12 @@ class PostingPhotoViewController: BaseViewController {
             $0.height.equalTo(90)
         }
     }
+
+    func showPHPicker() {
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
 }
 
 extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -93,12 +103,11 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
         
         return cell
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
         let width = UIScreen.main.bounds.width - 32
         let height = width / 4 * 3
-        
+
         return CGSize(width: width, height: height)
     }
     

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -123,8 +123,8 @@ class PostingPhotoViewController: BaseViewController {
     }
     
     private func didTapDeleteAction() {
-        photoCollectionView.reloadData()
         images.remove(at: selectedIndex)
+        photoCollectionView.reloadData()
     }
 }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -147,10 +147,39 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
 
         return CGSize(width: width, height: height)
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.selectedIndex = indexPath.item
         setupPHPickerConfigure()
+
+        // MARK: - ActionSheet
+
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let changePhoto = UIAlertAction(title: "사진 변경하기", style: .default) { _ in
+            self.isChangedConfigure = false
+            self.configuration.selectionLimit = 1
+            self.configuration.selection = .default
+
+            self.showPHPicker()
+            self.images.remove(at: self.selectedIndex)
+        }
+        let deletePhoto = UIAlertAction(title: "사진 삭제하기", style: .destructive) {
+            _ in
+            self.photoCollectionView.reloadData()
+            self.images.remove(at: self.selectedIndex)
+        }
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+
+        if (selectedIndex == 0) && (images[0] == emptyImage) {
+            self.isChangedConfigure = true
+            showPHPicker()
+        } else {
+            actionSheet.addAction(changePhoto)
+            actionSheet.addAction(deletePhoto)
+        }
+        actionSheet.addAction(cancel)
+
+        present(actionSheet, animated: true)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -22,7 +22,7 @@ class PostingPhotoViewController: BaseViewController {
 
     private lazy var images: [UIImage] = [emptyImage] {
         didSet {
-            nextButton.isEnabled = (images.count) > 1 ? true : false
+            nextButton.isEnabled = (images.count > 1) ? true : false
         }
     }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -11,6 +11,7 @@ import SnapKit
 
 class PostingPhotoViewController: BaseViewController {
     
+    private var uiButtonConfiguration = UIButton.Configuration.plain()
     // MARK: - View
     
     private let guidanceLabel: UILabel = {
@@ -30,15 +31,17 @@ class PostingPhotoViewController: BaseViewController {
                                               collectionViewLayout: UICollectionViewFlowLayout())
         return collectionView
     }()
-    
-    private let nextButton: UIButton = {
-        $0.setTitle("다음", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.backgroundColor = .blue
-        $0.layer.cornerRadius = 16
+
+    private lazy var nextButton: UIButton = {
+        $0.configuration?.title = "다음"
+        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.configuration?.baseForegroundColor = .white
+        $0.configuration?.contentInsets.bottom = 20
+        $0.backgroundColor = .gray
+        $0.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
         return $0
-    }(UIButton())
-    
+    }(UIButton(configuration: uiButtonConfiguration))
+
     // MARK: - Method
     
     override func attribute() {
@@ -51,25 +54,25 @@ class PostingPhotoViewController: BaseViewController {
     
     override func layout() {
         super.layout()
-        
+
         view.addSubview(guidanceLabel)
         guidanceLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
             $0.centerX.equalToSuperview()
         }
-        
+
         view.addSubview(photoCollectionView)
         photoCollectionView.snp.makeConstraints {
             $0.top.equalTo(guidanceLabel.snp.bottom).offset(16)
             $0.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
-        
+
         view.addSubview(nextButton)
         nextButton.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
-            $0.height.equalTo(50)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -16,7 +16,7 @@ class PostingPhotoViewController: BaseViewController {
 
     private var uiButtonConfiguration = UIButton.Configuration.plain()
     private var pickerConfiguration = PHPickerConfiguration()
-    private var isChangedConfigure = false
+    private var isChangedCondition = false
     private var selectedIndex = 0
     private let emptyImage = UIImage()
 
@@ -115,7 +115,6 @@ class PostingPhotoViewController: BaseViewController {
     }
     
     private func didTapChangeAction() {
-        isChangedConfigure = false
         pickerConfiguration.selectionLimit = 1
         pickerConfiguration.selection = .default
         showPHPicker()
@@ -166,13 +165,14 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
         setupPHPickerConfigure()
 
         if (selectedIndex == 0) && (images[0] == emptyImage) {
-            isChangedConfigure = true
+            isChangedCondition = true
             showPHPicker()
         } else {
             makeActionSheet(
                 firstContext: "사진 변경하기",
                 secondContext: "사진 삭제하기",
                 didTapFirst: { change in
+                    self.isChangedCondition = false
                     self.didTapChangeAction()
                 },
                 didTapSecond: { delete in
@@ -200,7 +200,7 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
                         self.images.insert(image,
-                                           at: self.isChangedConfigure ? self.selectedIndex + 1 : self.selectedIndex)
+                                           at: self.isChangedCondition ? self.selectedIndex + 1 : self.selectedIndex)
                         self.photoCollectionView.reloadData()
                     }
                 }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -67,7 +67,6 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     private func setupCollectionView() {
-        photoCollectionView.delegate = self
         photoCollectionView.dataSource = self
         photoCollectionView.register(PostingPhotoCell.self,
                                      forCellWithReuseIdentifier: PostingPhotoCell.identifier)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -124,6 +124,7 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingPhotoCell.identifier, for: indexPath) as! PostingPhotoCell
 
+        cell.plusIcon.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
 
         if (images.count == 6) && (images[0] == emptyImage) {
             images.remove(at: 0)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -72,7 +72,7 @@ class PostingPhotoViewController: BaseViewController {
         setupCollectionView()
     }
 
-    func setupCollectionView() {
+    private func setupCollectionView() {
         photoCollectionView.delegate = self
         photoCollectionView.dataSource = self
         photoCollectionView.register(PostingPhotoCell.self,
@@ -110,13 +110,13 @@ class PostingPhotoViewController: BaseViewController {
         present(alert, animated: true)
     }
 
-    func setupPHPickerConfigure() {
+    private func setupPHPickerConfigure() {
         configuration.selection = .ordered
         configuration.selectionLimit = (6 - images.count)
         configuration.filter = .any(of: [.images, .not(.livePhotos)])
     }
 
-    func showPHPicker() {
+    private func showPHPicker() {
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = self
         present(picker, animated: true)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -190,7 +190,7 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
                 item.loadObject(ofClass: UIImage.self) { (image, _) in
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
-                        
+
                         if self.isChangedPHPickerRole {
                             self.images.insert(image, at: self.selectedIndex + 1)
                         } else {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -104,10 +104,7 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     @objc func showAlert() {
-        let alert = UIAlertController(title: nil, message: "사진을 한 장 이상 선택해야 합니다.", preferredStyle: .alert)
-        let check = UIAlertAction(title: "확인", style: .default)
-        alert.addAction(check)
-        present(alert, animated: true)
+        makeAlert(title: nil, message: "사진을 한 장 이상 선택해야 합니다.")
     }
 
     private func setupPHPickerConfigure() {
@@ -121,8 +118,20 @@ class PostingPhotoViewController: BaseViewController {
         picker.delegate = self
         present(picker, animated: true)
     }
+    
+    private func didTapChangeAction() {
+        isChangedConfigure = false
         pickerConfiguration.selectionLimit = 1
         pickerConfiguration.selection = .default
+        showPHPicker()
+        
+        images.remove(at: selectedIndex)
+    }
+    
+    private func didTapDeleteAction() {
+        photoCollectionView.reloadData()
+        images.remove(at: selectedIndex)
+    }
 }
 
 extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -159,36 +168,24 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         self.selectedIndex = indexPath.item
+
         setupPHPickerConfigure()
 
-        // MARK: - ActionSheet
-
-        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let changePhoto = UIAlertAction(title: "사진 변경하기", style: .default) { _ in
-            self.isChangedConfigure = false
-            self.configuration.selectionLimit = 1
-            self.configuration.selection = .default
-
-            self.showPHPicker()
-            self.images.remove(at: self.selectedIndex)
-        }
-        let deletePhoto = UIAlertAction(title: "사진 삭제하기", style: .destructive) {
-            _ in
-            self.photoCollectionView.reloadData()
-            self.images.remove(at: self.selectedIndex)
-        }
-        let cancel = UIAlertAction(title: "취소", style: .cancel)
-
         if (selectedIndex == 0) && (images[0] == emptyImage) {
-            self.isChangedConfigure = true
+            isChangedConfigure = true
             showPHPicker()
         } else {
-            actionSheet.addAction(changePhoto)
-            actionSheet.addAction(deletePhoto)
+            makeActionSheet(
+                firstContext: "사진 변경하기",
+                secondContext: "사진 삭제하기",
+                didTapFirst: { change in
+                    self.didTapChangeAction()
+                },
+                didTapSecond: { delete in
+                    self.didTapDeleteAction()
+                }
+            )
         }
-        actionSheet.addAction(cancel)
-
-        present(actionSheet, animated: true)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -25,10 +25,11 @@ class PostingPhotoViewController: BaseViewController {
             if images.count > 1 {
                 // TODO: - 네비게이션 기능 필요.
                 nextButton.backgroundColor = .blue
+                nextButton.isEnabled = true
             } else {
                 nextButton.backgroundColor = .systemGray4
+                nextButton.isEnabled = false
             }
-            nextButton.isEnabled.toggle()
         }
     }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -118,13 +118,25 @@ class PostingPhotoViewController: BaseViewController {
 
 extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // TODO: - 이미지 갯수
-        return 1
+        return images.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingPhotoCell.identifier, for: indexPath) as! PostingPhotoCell
-        
+
+
+        if (images.count == 6) && (images[0] == emptyImage) {
+            images.remove(at: 0)
+            photoCollectionView.reloadData()
+        } else {
+            cell.postingImage.image = self.images[indexPath.item]
+
+            if images.count < 5 && !images.contains(emptyImage) {
+                images.insert(emptyImage, at: 0)
+                photoCollectionView.reloadData()
+            }
+        }
+
         return cell
     }
 
@@ -135,6 +147,11 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
         return CGSize(width: width, height: height)
     }
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.selectedIndex = indexPath.item
+        setupPHPickerConfigure()
+    }
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 20
     }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -119,8 +119,6 @@ class PostingPhotoViewController: BaseViewController {
         pickerConfiguration.selectionLimit = 1
         pickerConfiguration.selection = .default
         showPHPicker()
-        
-        images.remove(at: selectedIndex)
     }
     
     private func didTapDeleteAction() {
@@ -191,15 +189,19 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
 
         dismiss(animated: true)
 
-        let itemProviders = results.map { $0.itemProvider }
+        let itemProviders = results.map { $0.itemProvider }.reversed()
 
         for item in itemProviders {
             if item.canLoadObject(ofClass: UIImage.self) {
                 item.loadObject(ofClass: UIImage.self) { (image, _) in
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
-                        self.images.insert(image,
-                                           at: self.isChangedCondition ? self.selectedIndex + 1 : self.selectedIndex)
+                        
+                        if self.isChangedCondition {
+                            self.images.insert(image, at: self.selectedIndex + 1)
+                        } else {
+                            self.images[self.selectedIndex] = image
+                        }
                         self.photoCollectionView.reloadData()
                     }
                 }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -25,11 +25,10 @@ class PostingPhotoViewController: BaseViewController {
             if images.count > 1 {
                 // TODO: - 네비게이션 기능 필요.
                 nextButton.backgroundColor = .blue
-                nextButton.removeTarget(self, action: #selector(showAlert), for: .touchUpInside)
             } else {
-                nextButton.backgroundColor = .gray
-                nextButton.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
+                nextButton.backgroundColor = .systemGray4
             }
+            nextButton.isEnabled.toggle()
         }
     }
 
@@ -59,8 +58,8 @@ class PostingPhotoViewController: BaseViewController {
         $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.configuration?.baseForegroundColor = .white
         $0.configuration?.contentInsets.bottom = 20
-        $0.backgroundColor = .gray
-        $0.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
+        $0.backgroundColor = .systemGray4
+        $0.isEnabled = false
         return $0
     }(UIButton(configuration: uiButtonConfiguration))
 
@@ -101,10 +100,6 @@ class PostingPhotoViewController: BaseViewController {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
-    }
-
-    @objc func showAlert() {
-        makeAlert(title: nil, message: "사진을 한 장 이상 선택해야 합니다.")
     }
 
     private func setupPHPickerConfigure() {
@@ -155,7 +150,6 @@ extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionView
                 photoCollectionView.reloadData()
             }
         }
-
         return cell
     }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -84,7 +84,7 @@ class PostingPhotoViewController: BaseViewController {
 
         view.addSubview(guidanceLabel)
         guidanceLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(12)
             $0.centerX.equalToSuperview()
         }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -67,6 +67,7 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     private func setupCollectionView() {
+        photoCollectionView.delegate = self
         photoCollectionView.dataSource = self
         photoCollectionView.register(PostingPhotoCell.self,
                                      forCellWithReuseIdentifier: PostingPhotoCell.identifier)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -108,7 +108,7 @@ class PostingPhotoViewController: BaseViewController {
         picker.delegate = self
         present(picker, animated: true)
     }
-    
+
     private func didTapChangeAction() {
         pickerConfiguration.selectionLimit = 1
         pickerConfiguration.selection = .default

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -14,7 +14,7 @@ class PostingPhotoViewController: BaseViewController {
 
     // MARK: - Property
 
-    private var uiButtonConfiguration = UIButton.Configuration.plain()
+    private var buttonConfiguration = UIButton.Configuration.filled()
     private var pickerConfiguration = PHPickerConfiguration()
     private var isChangedPHPickerRole = false
     private var selectedIndex = 0
@@ -62,7 +62,7 @@ class PostingPhotoViewController: BaseViewController {
         $0.backgroundColor = .systemGray4
         $0.isEnabled = false
         return $0
-    }(UIButton(configuration: uiButtonConfiguration))
+    }(UIButton(configuration: buttonConfiguration))
 
     // MARK: - Method
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -43,13 +43,18 @@ class PostingPhotoViewController: BaseViewController {
     }(UIButton(configuration: uiButtonConfiguration))
 
     // MARK: - Method
-    
+
     override func attribute() {
         super.attribute()
-        
+
+        setupCollectionView()
+    }
+
+    func setupCollectionView() {
         photoCollectionView.delegate = self
         photoCollectionView.dataSource = self
-        photoCollectionView.register(PostingPhotoCell.self, forCellWithReuseIdentifier: PostingPhotoCell.identifier)
+        photoCollectionView.register(PostingPhotoCell.self,
+                                     forCellWithReuseIdentifier: PostingPhotoCell.identifier)
     }
     
     override func layout() {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -67,7 +67,6 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     private func setupCollectionView() {
-        photoCollectionView.delegate = self
         photoCollectionView.dataSource = self
         photoCollectionView.register(PostingPhotoCell.self,
                                      forCellWithReuseIdentifier: PostingPhotoCell.identifier)
@@ -121,7 +120,7 @@ class PostingPhotoViewController: BaseViewController {
     }
 }
 
-extension PostingPhotoViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return images.count
     }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 문의내역 사진 추가, 수정, 삭제할 수 있도록 하기 위함.
- 사진 없을 때, 사진 필수임을 사용자에게 알리기 위함
- 사진 최대 장수 제한하기 위함
- 사진 미리보기를 추가하기 위함.
- Plus 아이콘 사이즈를 줄이기 위함.

## Key Changes 🔥 (주요 구현/변경 사항)
- 사진 업로드 / 사진 셀
  - [x] 사진 업로드 가능한 셀 보여주기
  - [x] 이미 업로드된 경우 사진 셀 보여주기
- 사진 업로드 셀 클릭
  - [x] 사진 업로드 셀 클릭시 갤러리 형태로 포토 피커 보여주기
  - [x] 포토 피커에서 최대 5개까지 사진 선택 가능
- 사진 셀
  - [x] 사진이 업로드 되었을 경우 사진을 보여주는 셀 보여주기
  - [x] 사진 셀 클릭시 사진 수정, 사진 삭제 가능

## ToDo 📆 (남은 작업)
- [ ] 업로드 시 이미지 전체 순서가 바뀌는 버그
  - (추정) 이미지 확장자별 순서가 있는 것으로 보여짐.
    - 이미지 용량 축소 시 확장자 변경하면서 재확인 필요.
  - (X) 이미지 용량 및 크기에 의한 순서
- [x] 이미지가 사라지는 버그(원인미상)
- [ ] 사진 라이브러리 권한 알림

## ScreenShot 📷 (참고 사진)
![Simulator Screen Recording - iPhone 14 Pro - 2023-01-24 at 14 28 32](https://user-images.githubusercontent.com/98405970/214218687-bab16ff8-c287-48fd-966f-e1b2be4f1a1a.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 일부 버그가 있으나, 현재 작업한 내용까지 PR올렸습니다. 
- 추가 버그 발생 시 어떤 상황에서의 버그인지 체크해주시면 감사하겠습니다.
- **UIButtonConfiguration사용 이유**
  - 기존 ContentEdgeInsets는 iOS 15.0에서 Deprecated되어, 16버전까지는 지원이 되나, 이후 버전부터는 지원여부를 알 수 없기 때문임.
  - <img width="1038" alt="스크린샷 2023-01-24 오후 2 36 55" src="https://user-images.githubusercontent.com/98405970/214219755-a2c98421-6b13-4e31-8719-3c174f30efa9.png">
  - UIButtonConfiguration사용 시, 기본 버튼 UI에 CornerRadius가 반영되어 있는 것으로 보아, Apple에서는 일관된 기본 버튼 UI를 적용시키려는 것으로 생각되어지네요.

## Reference 🔗
- [PHPicker 참고자료](https://velog.io/@wannabe_eung/앨범의-이미지를-선택할-수-있는-PHPickerViewController를-알아보자)
- [UIButtonConfiguration 참고자료](https://velog.io/@wannabe_eung/iOS-UIButton-Configuration-사용해보기-in-iOS-15)

## Close Issues 🔒 (닫을 Issue)
Close #22.
