### PR TITLE
[Feature] 문의내역 작성하기 버튼 동작

### DIFF
--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		438E5B2A297982E300FD947E /* HideKeyboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438E5B29297982E300FD947E /* HideKeyboard+.swift */; };
 		43997B052981367200C5A163 /* PostImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43997B042981367200C5A163 /* PostImageViewController.swift */; };
 		43E1F565297A16CD000A13D4 /* Alert+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1F564297A16CD000A13D4 /* Alert+.swift */; };
+		9839F36F298B55350058639F /* SegmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9839F36E298B55350058639F /* SegmentCoordinator.swift */; };
+		9839F371298B5BD00058639F /* PostingPhotoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9839F370298B5BD00058639F /* PostingPhotoCoordinator.swift */; };
 		98419D74297C0554005E0EF6 /* PostingPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */; };
 		98419D76297C1BF9005E0EF6 /* PostingPhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98419D75297C1BF9005E0EF6 /* PostingPhotoCell.swift */; };
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
@@ -62,6 +64,8 @@
 		43997B042981367200C5A163 /* PostImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostImageViewController.swift; sourceTree = "<group>"; };
 		43E1F564297A16CD000A13D4 /* Alert+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+.swift"; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
+		9839F36E298B55350058639F /* SegmentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentCoordinator.swift; sourceTree = "<group>"; };
+		9839F370298B5BD00058639F /* PostingPhotoCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPhotoCoordinator.swift; sourceTree = "<group>"; };
 		98419D73297C0554005E0EF6 /* PostingPhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPhotoViewController.swift; sourceTree = "<group>"; };
 		98419D75297C1BF9005E0EF6 /* PostingPhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPhotoCell.swift; sourceTree = "<group>"; };
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
@@ -132,6 +136,8 @@
 				260A63DF29710834004034AD /* AppCoordinator.swift */,
 				260A63E129710846004034AD /* MainCoordinator.swift */,
 				260A63E729710A7F004034AD /* SubCoordinator.swift */,
+				9839F36E298B55350058639F /* SegmentCoordinator.swift */,
+				9839F370298B5BD00058639F /* PostingPhotoCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -361,6 +367,7 @@
 				988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */,
 				260A63E429710A45004034AD /* MainViewController.swift in Sources */,
 				260A63DA297107B8004034AD /* Service.swift in Sources */,
+				9839F371298B5BD00058639F /* PostingPhotoCoordinator.swift in Sources */,
 				438BF0432977CA28005E4CF3 /* EnterViewController.swift in Sources */,
 				988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */,
 				260A63D8297107AA004034AD /* Cell.swift in Sources */,
@@ -375,6 +382,7 @@
 				98F52B842982BA28002C1303 /* PostCell.swift in Sources */,
 				98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */,
 				988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */,
+				9839F36F298B55350058639F /* SegmentCoordinator.swift in Sources */,
 				43E1F565297A16CD000A13D4 /* Alert+.swift in Sources */,
 				98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */,
 				260A63CA29710725004034AD /* Model.swift in Sources */,

--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		988C56D029768F2D00018F07 /* SegmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56CF29768F2D00018F07 /* SegmentViewController.swift */; };
 		988C56D42976D3BA00018F07 /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D32976D3BA00018F07 /* HistoryCell.swift */; };
 		988C56D8297777E500018F07 /* ProgressHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D7297777E500018F07 /* ProgressHeader.swift */; };
-		988C56DA29779D2A00018F07 /* PostDateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D929779D2A00018F07 /* PostDateCell.swift */; };
+		988C56DA29779D2A00018F07 /* PostDateHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56D929779D2A00018F07 /* PostDateHeader.swift */; };
 		988C56DC2978349D00018F07 /* HistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988C56DB2978349D00018F07 /* HistoryViewController.swift */; };
 		98D44B722941DD4B00386AA4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B712941DD4B00386AA4 /* AppDelegate.swift */; };
 		98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D44B732941DD4B00386AA4 /* SceneDelegate.swift */; };
@@ -71,7 +71,7 @@
 		988C56CF29768F2D00018F07 /* SegmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentViewController.swift; sourceTree = "<group>"; };
 		988C56D32976D3BA00018F07 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
 		988C56D7297777E500018F07 /* ProgressHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHeader.swift; sourceTree = "<group>"; };
-		988C56D929779D2A00018F07 /* PostDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDateCell.swift; sourceTree = "<group>"; };
+		988C56D929779D2A00018F07 /* PostDateHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDateHeader.swift; sourceTree = "<group>"; };
 		988C56DB2978349D00018F07 /* HistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewController.swift; sourceTree = "<group>"; };
 		98D44B6E2941DD4B00386AA4 /* GiwazipClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GiwazipClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D44B712941DD4B00386AA4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -147,11 +147,11 @@
 			children = (
 				260A63D7297107AA004034AD /* Cell.swift */,
 				988C56D7297777E500018F07 /* ProgressHeader.swift */,
-				988C56D929779D2A00018F07 /* PostDateCell.swift */,
+				432511532988140700F08BD2 /* ASCell.swift */,
+				988C56D929779D2A00018F07 /* PostDateHeader.swift */,
 				988C56D32976D3BA00018F07 /* HistoryCell.swift */,
 				98419D75297C1BF9005E0EF6 /* PostingPhotoCell.swift */,
 				98F52B832982BA28002C1303 /* PostCell.swift */,
-				432511532988140700F08BD2 /* ASCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -386,7 +386,7 @@
 				43E1F565297A16CD000A13D4 /* Alert+.swift in Sources */,
 				98D44B742941DD4B00386AA4 /* SceneDelegate.swift in Sources */,
 				260A63CA29710725004034AD /* Model.swift in Sources */,
-				988C56DA29779D2A00018F07 /* PostDateCell.swift in Sources */,
+				988C56DA29779D2A00018F07 /* PostDateHeader.swift in Sources */,
 				432511542988140700F08BD2 /* ASCell.swift in Sources */,
 				260A63DC297107C3004034AD /* BaseViewController.swift in Sources */,
 				98F52B822982B476002C1303 /* PostViewController.swift in Sources */,

--- a/GiwazipClient/Cells/ASCell.swift
+++ b/GiwazipClient/Cells/ASCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class ASCell: UICollectionReusableView {
+class ASCell: UICollectionViewCell {
     
     // MARK: - Property
     

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -89,7 +89,7 @@ class HistoryCell: UICollectionViewCell {
         
         postImage.addSubview(descriptionBackground)
         descriptionBackground.snp.makeConstraints {
-            $0.bottom.width.equalToSuperview()
+            $0.bottom.horizontalEdges.equalToSuperview()
         }
         
         descriptionBackground.addSubview(postDescription)

--- a/GiwazipClient/Cells/HistoryCell.swift
+++ b/GiwazipClient/Cells/HistoryCell.swift
@@ -71,9 +71,7 @@ class HistoryCell: UICollectionViewCell {
     private func setupCell() {
         self.addSubview(postImage)
         postImage.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(UIScreen.main.bounds.width / 4 * 3)
+            $0.edges.equalToSuperview()
         }
         
         postImage.addSubview(chipFrame)

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -54,11 +54,12 @@ class PostDateCell: UICollectionViewCell {
         self.addSubview(dateStack)
         dateStack.snp.makeConstraints {
             $0.top.equalToSuperview().offset(16)
+            $0.horizontalEdges.equalToSuperview()
         }
         
         dateStack.addSubview(leftDashLine)
         leftDashLine.snp.makeConstraints {
-            $0.left.centerY.equalToSuperview()
+            $0.verticalEdges.left.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
         }
@@ -72,8 +73,8 @@ class PostDateCell: UICollectionViewCell {
         
         dateStack.addSubview(rightDashLine)
         rightDashLine.snp.makeConstraints {
+            $0.verticalEdges.right.centerY.equalToSuperview()
             $0.left.equalTo(postingDate.snp.right)
-            $0.right.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
         }

--- a/GiwazipClient/Cells/PostDateCell.swift
+++ b/GiwazipClient/Cells/PostDateCell.swift
@@ -53,13 +53,13 @@ class PostDateCell: UICollectionViewCell {
     private func setupCell() {
         self.addSubview(dateStack)
         dateStack.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(16)
+            $0.verticalEdges.equalToSuperview().offset(8)
             $0.horizontalEdges.equalToSuperview()
         }
         
         dateStack.addSubview(leftDashLine)
         leftDashLine.snp.makeConstraints {
-            $0.verticalEdges.left.centerY.equalToSuperview()
+            $0.left.centerY.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)
         }
@@ -68,12 +68,12 @@ class PostDateCell: UICollectionViewCell {
         postingDate.snp.makeConstraints {
             $0.left.equalTo(leftDashLine.snp.right)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
-            $0.centerY.equalToSuperview()
+            $0.verticalEdges.equalToSuperview()
         }
         
         dateStack.addSubview(rightDashLine)
         rightDashLine.snp.makeConstraints {
-            $0.verticalEdges.right.centerY.equalToSuperview()
+            $0.right.centerY.equalToSuperview()
             $0.left.equalTo(postingDate.snp.right)
             $0.width.equalTo(UIScreen.main.bounds.width / 3)
             $0.height.equalTo(1)

--- a/GiwazipClient/Cells/PostDateHeader.swift
+++ b/GiwazipClient/Cells/PostDateHeader.swift
@@ -1,5 +1,5 @@
 //
-//  PostDateCell.swift
+//  PostDateHeader.swift
 //  GiwazipClient
 //
 //  Created by 지준용 on 2023/01/18.
@@ -9,11 +9,11 @@ import UIKit
 
 import SnapKit
 
-class PostDateCell: UICollectionViewCell {
+class PostDateHeader: UICollectionReusableView {
     
     // MARK: - Property
     
-    static let identifier = "postDateCell"
+    static let identifier = "postDateHeader"
     
     // MARK: - View
     
@@ -53,8 +53,7 @@ class PostDateCell: UICollectionViewCell {
     private func setupCell() {
         self.addSubview(dateStack)
         dateStack.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().offset(8)
-            $0.horizontalEdges.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
         
         dateStack.addSubview(leftDashLine)

--- a/GiwazipClient/Cells/ProgressHeader.swift
+++ b/GiwazipClient/Cells/ProgressHeader.swift
@@ -38,7 +38,7 @@ class ProgressHeader: UICollectionReusableView {
     private func setupCell() {
         addSubview(progressBlock)
         progressBlock.snp.makeConstraints {
-            $0.top.size.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/GiwazipClient/Coordinators/AppCoordinator.swift
+++ b/GiwazipClient/Coordinators/AppCoordinator.swift
@@ -7,19 +7,21 @@
 
 import UIKit
 
-class AppCoordinator: BaseCoordinator, MainCoordinatorDelegate, SubCoordinatorDelegate {
+class AppCoordinator: BaseCoordinator, MainCoordinatorDelegate, SubCoordinatorDelegate, SegmentCoordinatorDelegate {
 
-    var isLoggedIn = false
+    var isLoggedIn = true
 
     // MARK: - Method
 
     override func start() {
         if isLoggedIn {
-            showSubViewController()
+            showSegmentViewController()
         } else {
             showMainViewController()
         }
     }
+
+    // MARK: - ViewController
 
     private func showSubViewController() {
         let coordinator = SubCoordinator(navigationController: navigationController)
@@ -34,6 +36,21 @@ class AppCoordinator: BaseCoordinator, MainCoordinatorDelegate, SubCoordinatorDe
         coordinator.start()
         self.childCoordinators.append(coordinator)
     }
+    
+    private func showSegmentViewController() {
+        let coordinator = SegmentCoordinator(navigationController: navigationController)
+        coordinator.delegate = self
+        coordinator.start()
+        self.childCoordinators.append(coordinator)
+    }
+    
+    private func showPostingPhotoViewController() {
+        let coordinator = PostingPhotoCoordinator(navigationController: navigationController)
+        coordinator.start()
+        self.childCoordinators.append(coordinator)
+    }
+
+    // MARK: - Click Event
 
     func didLoggedIn(_ coordinator: MainCoordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0 !== coordinator }
@@ -43,6 +60,11 @@ class AppCoordinator: BaseCoordinator, MainCoordinatorDelegate, SubCoordinatorDe
     func didLoggedOut(_ coordinator: SubCoordinator) {
         self.childCoordinators = self.childCoordinators.filter { $0 !== coordinator }
         self.showMainViewController()
+    }
+    
+    func presentPostingPhotoView(_ coordinator: SegmentCoordinator) {
+        self.childCoordinators = self.childCoordinators.filter{ $0 !== coordinator }
+        showPostingPhotoViewController()
     }
 }
 

--- a/GiwazipClient/Coordinators/AppCoordinator.swift
+++ b/GiwazipClient/Coordinators/AppCoordinator.swift
@@ -21,7 +21,7 @@ class AppCoordinator: BaseCoordinator, MainCoordinatorDelegate, SubCoordinatorDe
         }
     }
 
-    // MARK: - ViewController
+    // MARK: - ShowVC Method
 
     private func showSubViewController() {
         let coordinator = SubCoordinator(navigationController: navigationController)

--- a/GiwazipClient/Coordinators/MainCoordinator.swift
+++ b/GiwazipClient/Coordinators/MainCoordinator.swift
@@ -43,6 +43,7 @@ protocol MainCoordinatorDelegate {
 class MainCoordinator: BaseCoordinator, MainViewControllerDelegate {
 
     // MARK: - Property
+
     var delegate: MainCoordinatorDelegate?
 
     // MARK: - Method

--- a/GiwazipClient/Coordinators/PostingPhotoCoordinator.swift
+++ b/GiwazipClient/Coordinators/PostingPhotoCoordinator.swift
@@ -1,0 +1,20 @@
+//
+//  PostingPhotoCoordinator.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/02/02.
+//
+
+import UIKit
+
+class PostingPhotoCoordinator: BaseCoordinator, PostingPhotoViewControllerDelegate {
+    override func start() {
+        let postingPhotoViewController = PostingPhotoViewController()
+        postingPhotoViewController.delegate = self
+
+        let navigationController = UINavigationController(rootViewController: postingPhotoViewController)
+        navigationController.modalPresentationStyle = .fullScreen
+
+        self.navigationController.present(navigationController, animated: true)
+    }
+}

--- a/GiwazipClient/Coordinators/SegmentCoordinator.swift
+++ b/GiwazipClient/Coordinators/SegmentCoordinator.swift
@@ -1,0 +1,28 @@
+//
+//  SegmentCoordinator.swift
+//  GiwazipClient
+//
+//  Created by 지준용 on 2023/02/02.
+//
+
+import Foundation
+
+protocol SegmentCoordinatorDelegate {
+    func presentPostingPhotoView(_ coordinator: SegmentCoordinator)
+}
+
+class SegmentCoordinator: BaseCoordinator, SegmentViewControllerDelegate {
+
+    var delegate: SegmentCoordinatorDelegate?
+
+    override func start() {
+        let segmentViewController = SegmentViewController()
+        segmentViewController.delegate = self
+
+        navigationController.viewControllers = [segmentViewController]
+    }
+
+    func presentPostingPhotoView() {
+        self.delegate?.presentPostingPhotoView(self)
+    }
+}

--- a/GiwazipClient/Coordinators/SegmentCoordinator.swift
+++ b/GiwazipClient/Coordinators/SegmentCoordinator.swift
@@ -13,8 +13,12 @@ protocol SegmentCoordinatorDelegate {
 
 class SegmentCoordinator: BaseCoordinator, SegmentViewControllerDelegate {
 
+    // MARK: - Property
+    
     var delegate: SegmentCoordinatorDelegate?
 
+    // MARK: - Method
+    
     override func start() {
         let segmentViewController = SegmentViewController()
         segmentViewController.delegate = self

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -11,6 +11,12 @@ import SnapKit
 
 class HistoryViewController: BaseViewController {
     
+    // MARK: - Property
+    
+    private var buttonConfiguration = UIButton.Configuration.filled()
+    
+    // MARK: - View
+    
     private let historyCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero,
                                               collectionViewLayout: UICollectionViewFlowLayout())
@@ -25,6 +31,18 @@ class HistoryViewController: BaseViewController {
         $0.isHidden = true
         return $0
     }(UILabel())
+    
+    private lazy var inquiryButton: UIButton = {
+        $0.configuration?.title = "문의하기"
+        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.configuration?.baseForegroundColor = .white
+        $0.configuration?.baseBackgroundColor = .blue
+        $0.configuration?.background.cornerRadius = 0
+        $0.configuration?.contentInsets.bottom = 20
+        return $0
+    }(UIButton(configuration: buttonConfiguration))
+    
+    // MARK: - Method
     
     override func attribute() {
         super.attribute()
@@ -48,6 +66,12 @@ class HistoryViewController: BaseViewController {
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
+        }
+        
+        view.addSubview(inquiryButton)
+        inquiryButton.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -28,16 +28,6 @@ class HistoryViewController: BaseViewController {
         return $0
     }(UILabel())
 
-    private lazy var inquiryButton: UIButton = {
-        $0.configuration?.title = "문의하기"
-        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
-        $0.configuration?.baseForegroundColor = .white
-        $0.configuration?.baseBackgroundColor = .blue
-        $0.configuration?.background.cornerRadius = 0
-        $0.configuration?.contentInsets.bottom = 20
-        return $0
-    }(UIButton(configuration: buttonConfiguration))
-
     // MARK: - Method
 
     override func attribute() {

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -10,19 +10,15 @@ import UIKit
 import SnapKit
 
 class HistoryViewController: BaseViewController {
-    
-    // MARK: - Property
-    
-    private var buttonConfiguration = UIButton.Configuration.filled()
-    
+
     // MARK: - View
-    
+
     private let historyCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero,
                                               collectionViewLayout: UICollectionViewFlowLayout())
         return collectionView
     }()
-    
+
     private let microCopy: UILabel = {
         $0.text = "아직 진행 중인 시공이 없습니다."
         $0.textColor = .gray
@@ -31,17 +27,7 @@ class HistoryViewController: BaseViewController {
         $0.isHidden = true
         return $0
     }(UILabel())
-    
-    private lazy var inquiryButton: UIButton = {
-        $0.configuration?.title = "문의하기"
-        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
-        $0.configuration?.baseForegroundColor = .white
-        $0.configuration?.baseBackgroundColor = .blue
-        $0.configuration?.background.cornerRadius = 0
-        $0.configuration?.contentInsets.bottom = 20
-        return $0
-    }(UIButton(configuration: buttonConfiguration))
-    
+
     // MARK: - Method
     
     override func attribute() {
@@ -66,12 +52,6 @@ class HistoryViewController: BaseViewController {
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        view.addSubview(inquiryButton)
-        inquiryButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -42,23 +42,23 @@ class HistoryViewController: BaseViewController {
 
     override func attribute() {
         super.attribute()
-        
+
         historyCollectionView.delegate = self
         historyCollectionView.dataSource = self
-        
-        historyCollectionView.register(ASCell.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ASCell.identifier)
-        historyCollectionView.register(PostDateCell.self, forCellWithReuseIdentifier: PostDateCell.identifier)
+
+        historyCollectionView.register(PostDateHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: PostDateHeader.identifier)
+        historyCollectionView.register(ASCell.self, forCellWithReuseIdentifier: ASCell.identifier)
         historyCollectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
-        
+
         historyCollectionView.showsVerticalScrollIndicator = false
     }
-    
+
     override func layout() {
         view.addSubview(historyCollectionView)
         historyCollectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-        
+
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
@@ -67,48 +67,62 @@ class HistoryViewController: BaseViewController {
 }
 
 extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-    
+
     // MARK: - Section
-    
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 3
+    }
+
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        // TODO: - 게시물 데이터 반영
-        return 5
+        // TODO: - 5에 게시물 데이터 갯수 반영
+        return section == 0 ? 1 : 2
     }
-    
+
     // MARK: - Header
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        return CGSize(width: screenWidth, height: 180)
+        if section == 0 {
+            return CGSize.zero
+        }
+        return CGSize(width: screenWidth, height: 40)
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ASCell.identifier, for: indexPath) as! ASCell
-        // TODO: - 진행률 반영
+        var header = UICollectionReusableView()
+
+        if indexPath.section > 0 {
+            header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: PostDateHeader.identifier, for: indexPath) as! PostDateHeader
+            // TODO: - 날짜 데이터 반영
+        }
+
         return header
     }
-    
+
     // MARK: - Cell
-    
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         var cell = UICollectionViewCell()
-        
-        if indexPath.row == 0 {
-            cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostDateCell.identifier, for: indexPath) as! PostDateCell
-            // TODO: - 날짜 데이터 반영
+
+        if indexPath.section == 0 {
+            cell = collectionView.dequeueReusableCell(withReuseIdentifier: ASCell.identifier, for: indexPath) as! ASCell
+            // TODO: - 진행률 반영
         } else {
             cell = collectionView.dequeueReusableCell(withReuseIdentifier: HistoryCell.identifier, for: indexPath) as! HistoryCell
             // TODO: - 게시물 데이터 반영
         }
+
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        if indexPath.row == 0 {
-            return CGSize(width: screenWidth, height: 20)
+        if indexPath.section == 0 {
+            return CGSize(width: screenWidth, height: 180)
         }
-        return CGSize(width: screenWidth, height: screenWidth / 4 * 3)
+
+        return CGSize(width: screenWidth - 32, height: screenWidth / 4 * 3)
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 20
     }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -32,8 +32,6 @@ class HistoryViewController: BaseViewController {
         return $0
     }(UILabel())
 
-    // MARK: - Method
-    
     private lazy var inquiryButton: UIButton = {
         $0.configuration?.title = "문의하기"
         $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
@@ -45,7 +43,7 @@ class HistoryViewController: BaseViewController {
     }(UIButton(configuration: buttonConfiguration))
 
     // MARK: - Method
-    
+
     override func attribute() {
         super.attribute()
         
@@ -68,12 +66,6 @@ class HistoryViewController: BaseViewController {
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        view.addSubview(inquiryButton)
-        inquiryButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -11,10 +11,6 @@ import SnapKit
 
 class HistoryViewController: BaseViewController {
 
-    // MARK: - Property
-
-    private var buttonConfiguration = UIButton.Configuration.filled()
-
     // MARK: - View
 
     private let historyCollectionView: UICollectionView = {

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -11,6 +11,10 @@ import SnapKit
 
 class HistoryViewController: BaseViewController {
 
+    // MARK: - Property
+
+    private var buttonConfiguration = UIButton.Configuration.filled()
+
     // MARK: - View
 
     private let historyCollectionView: UICollectionView = {
@@ -28,6 +32,18 @@ class HistoryViewController: BaseViewController {
         return $0
     }(UILabel())
 
+    // MARK: - Method
+    
+    private lazy var inquiryButton: UIButton = {
+        $0.configuration?.title = "문의하기"
+        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.configuration?.baseForegroundColor = .white
+        $0.configuration?.baseBackgroundColor = .blue
+        $0.configuration?.background.cornerRadius = 0
+        $0.configuration?.contentInsets.bottom = 20
+        return $0
+    }(UIButton(configuration: buttonConfiguration))
+    
     // MARK: - Method
     
     override func attribute() {
@@ -52,6 +68,12 @@ class HistoryViewController: BaseViewController {
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
+        }
+        
+        view.addSubview(inquiryButton)
+        inquiryButton.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -34,18 +34,6 @@ class HistoryViewController: BaseViewController {
 
     // MARK: - Method
     
-    private lazy var inquiryButton: UIButton = {
-        $0.configuration?.title = "문의하기"
-        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
-        $0.configuration?.baseForegroundColor = .white
-        $0.configuration?.baseBackgroundColor = .blue
-        $0.configuration?.background.cornerRadius = 0
-        $0.configuration?.contentInsets.bottom = 20
-        return $0
-    }(UIButton(configuration: buttonConfiguration))
-    
-    // MARK: - Method
-    
     override func attribute() {
         super.attribute()
         
@@ -68,12 +56,6 @@ class HistoryViewController: BaseViewController {
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        view.addSubview(inquiryButton)
-        inquiryButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -60,10 +60,6 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
     
     // MARK: - Section
     
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
-    }
-    
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         // TODO: - 게시물 데이터 반영
         return 5

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -43,7 +43,7 @@ class HistoryViewController: BaseViewController {
         $0.configuration?.contentInsets.bottom = 20
         return $0
     }(UIButton(configuration: buttonConfiguration))
-    
+
     // MARK: - Method
     
     override func attribute() {
@@ -68,12 +68,6 @@ class HistoryViewController: BaseViewController {
         view.addSubview(microCopy)
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
-        }
-        
-        view.addSubview(inquiryButton)
-        inquiryButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(90)
         }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -69,6 +69,12 @@ class HistoryViewController: BaseViewController {
         microCopy.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
+        
+        view.addSubview(inquiryButton)
+        inquiryButton.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(90)
+        }
     }
 }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -10,10 +10,15 @@ import UIKit
 
 import SnapKit
 
+protocol PostingPhotoViewControllerDelegate {
+    
+}
+
 class PostingPhotoViewController: BaseViewController {
 
     // MARK: - Property
 
+    var delegate: PostingPhotoViewControllerDelegate?
     private var buttonConfiguration = UIButton.Configuration.filled()
     private var pickerConfiguration = PHPickerConfiguration()
     private var isChangedPHPickerRole = false

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -9,10 +9,15 @@ import UIKit
 
 import SnapKit
 
+protocol SegmentViewControllerDelegate {
+    func presentPostingPhotoView()
+}
+
 class SegmentViewController: BaseViewController {
     
     // MARK: - Property
 
+    var delegate: SegmentViewControllerDelegate?
     private var buttonConfiguration = UIButton.Configuration.filled()
     private lazy var segmentedViewControllers: [UIViewController] = [workingView, inquiryView]
     
@@ -80,6 +85,7 @@ class SegmentViewController: BaseViewController {
         $0.configuration?.baseBackgroundColor = .blue
         $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
+        $0.addTarget(self, action: #selector(moveViewController), for: .touchUpInside)
         return $0
     }(UIButton(configuration: buttonConfiguration))
     
@@ -144,7 +150,6 @@ class SegmentViewController: BaseViewController {
 
         pageContentView.addSubview(pageViewController.view)
         pageViewController.view.snp.makeConstraints {
-//            $0.size.equalToSuperview()
             $0.edges.equalToSuperview()
         }
 
@@ -189,6 +194,10 @@ class SegmentViewController: BaseViewController {
     
     @objc func selectedSegmentControl(control: UISegmentedControl) {
         currentViewNum = control.selectedSegmentIndex
+    }
+    
+    @objc func moveViewController() {
+        delegate?.presentPostingPhotoView()
     }
 }
 

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -36,11 +36,11 @@ class SegmentViewController: BaseViewController {
             }
         }
     }
-    
+
     // MARK: - View
-    
+
     private let titleView = UIView()
-    
+
     private let titleName: UILabel = {
         $0.text = "디너집"
         $0.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
@@ -48,7 +48,7 @@ class SegmentViewController: BaseViewController {
         $0.textColor = .black
         return $0
     }(UILabel())
-    
+
     private let titleDate: UILabel = {
         $0.text = "22.11.11~23.01.13"
         $0.font = UIFont.systemFont(ofSize: 14, weight: .regular)
@@ -56,21 +56,21 @@ class SegmentViewController: BaseViewController {
         $0.textColor = .gray
         return $0
     }(UILabel())
-    
+
     private let segmentedControl = UISegmentedControl(items: ["시공내역", "문의내역"])
-    
+
     private let workingView: HistoryViewController = {
         // TODO: - 추후 데이터 추가
         return $0
     }(HistoryViewController())
-    
+
     private let inquiryView: HistoryViewController = {
         // TODO: - 추후 데이터 추가
         return $0
     }(HistoryViewController())
-    
+
     private let pageContentView = UIView()
-    
+
     private lazy var pageViewController: UIPageViewController = {
         $0.setViewControllers([segmentedViewControllers[0]],
                               direction: .forward,
@@ -78,7 +78,7 @@ class SegmentViewController: BaseViewController {
         return $0
     }(UIPageViewController(transitionStyle: .scroll,
                            navigationOrientation: .horizontal))
-    
+
     private lazy var inquiryButton: UIButton = {
         $0.configuration?.title = "문의하기"
         $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
@@ -90,14 +90,14 @@ class SegmentViewController: BaseViewController {
         $0.isEnabled = false
         return $0
     }(UIButton(configuration: buttonConfiguration))
-    
+
     // MARK: - Method
-    
+
     override func attribute() {
         super.attribute()
-        
+
         inquiryButton.bounds = CGRect(x: 0, y: -90, width: UIScreen.main.bounds.width, height: 90)
-        
+
         setupNavigationTitle()
         setupSegmentedControl()
         
@@ -114,25 +114,25 @@ class SegmentViewController: BaseViewController {
         )
         navigationItem.rightBarButtonItem?.tintColor = .black
     }
-    
+
     private func navigationLayout() {
         self.navigationItem.titleView = titleView
         titleView.snp.makeConstraints {
             $0.height.equalTo(navigationItem.titleView!.snp.height)
         }
-        
+
         titleView.addSubview(titleName)
         titleName.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
         }
-        
+
         titleView.addSubview(titleDate)
         titleDate.snp.makeConstraints {
             $0.top.equalTo(titleName.snp.bottom)
             $0.bottom.horizontalEdges.equalToSuperview()
         }
     }
-    
+
     override func layout() {
         navigationLayout()
 
@@ -168,7 +168,7 @@ class SegmentViewController: BaseViewController {
         }
         
     }
-    
+
     private func setupSegmentedControl() {
         segmentedControl.setTitleTextAttributes(
             [NSAttributedString.Key
@@ -178,10 +178,10 @@ class SegmentViewController: BaseViewController {
             [NSAttributedString.Key
                 .foregroundColor: UIColor.black,
                 .font: UIFont.systemFont(ofSize: 20, weight: .bold)], for: .selected)
-        
+
         segmentedControl.selectedSegmentIndex = 0
         segmentedControl.addTarget(self, action: #selector(selectedSegmentControl), for: .valueChanged)
-        
+
         removeSegmentDefaultConfigure()
     }
     
@@ -199,11 +199,11 @@ class SegmentViewController: BaseViewController {
                                          rightSegmentState: .normal,
                                          barMetrics: .default)
     }
-    
+
     @objc func selectedSegmentControl(control: UISegmentedControl) {
         currentViewNum = control.selectedSegmentIndex
     }
-    
+
     @objc func moveViewController() {
         delegate?.presentPostingPhotoView()
     }

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -166,7 +166,6 @@ class SegmentViewController: BaseViewController {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
-        
     }
 
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -160,6 +160,13 @@ class SegmentViewController: BaseViewController {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
+
+        pageContentView.addSubview(inquiryButton)
+        inquiryButton.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(90)
+        }
+        
     }
     
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -32,6 +32,7 @@ class SegmentViewController: BaseViewController {
                 } else {
                     self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: -90)
                 }
+                self.inquiryButton.isEnabled.toggle()
             }
         }
     }
@@ -81,11 +82,12 @@ class SegmentViewController: BaseViewController {
     private lazy var inquiryButton: UIButton = {
         $0.configuration?.title = "문의하기"
         $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
-        $0.configuration?.baseForegroundColor = .white
-        $0.configuration?.baseBackgroundColor = .blue
+        $0.configuration?.attributedTitle?.foregroundColor = .white
+        $0.configuration?.background.backgroundColor = .blue
         $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
         $0.addTarget(self, action: #selector(moveViewController), for: .touchUpInside)
+        $0.isEnabled = false
         return $0
     }(UIButton(configuration: buttonConfiguration))
     

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -12,13 +12,24 @@ import SnapKit
 class SegmentViewController: BaseViewController {
     
     // MARK: - Property
-    
+
+    private var buttonConfiguration = UIButton.Configuration.filled()
     private lazy var segmentedViewControllers: [UIViewController] = [workingView, inquiryView]
     
     private var currentViewNum: Int = 0 {
         didSet {
             let direction: UIPageViewController.NavigationDirection = (oldValue <= currentViewNum ? .forward : .reverse)
             pageViewController.setViewControllers([segmentedViewControllers[currentViewNum]], direction: direction, animated: true)
+            
+            UIView.animate(withDuration: 0.8) {
+                if self.currentViewNum == 1 {
+                    self.inquiryButton.isHidden = false
+
+                    self.inquiryButton.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 0)
+                } else {
+                    self.inquiryButton.frame = CGRect(x: 0, y: UIScreen.main.bounds.height, width: UIScreen.main.bounds.width, height: 90)
+                }
+            }
         }
     }
     
@@ -64,6 +75,18 @@ class SegmentViewController: BaseViewController {
     }(UIPageViewController(transitionStyle: .scroll,
                            navigationOrientation: .horizontal))
     
+    private lazy var inquiryButton: UIButton = {
+        $0.configuration?.title = "문의하기"
+        $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        $0.configuration?.baseForegroundColor = .white
+        $0.configuration?.baseBackgroundColor = .blue
+        $0.configuration?.background.cornerRadius = 0
+        $0.configuration?.contentInsets.bottom = 20
+//        $0.frame = CGRect(x: 0, y: UIScreen.main.bounds.height, width: UIScreen.main.bounds.width, height: 90)
+        $0.isHidden = true
+        return $0
+    }(UIButton(configuration: buttonConfiguration))
+    
     // MARK: - Method
     
     override func attribute() {
@@ -106,26 +129,32 @@ class SegmentViewController: BaseViewController {
     
     override func layout() {
         navigationLayout()
-        
-        view.addSubview(segmentedControl)
-        view.addSubview(pageContentView)
-        pageContentView.addSubview(pageViewController.view)
 
+        view.addSubview(segmentedControl)
         segmentedControl.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
-            $0.bottom.equalTo(pageContentView.snp.top).offset(-12)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(12)
             $0.left.equalToSuperview().offset(16)
             $0.width.equalTo(180)
             $0.height.equalTo(20)
         }
-        
+
+        view.addSubview(pageContentView)
         pageContentView.snp.makeConstraints {
+            $0.top.equalTo(segmentedControl.snp.bottom).offset(12)
             $0.bottom.width.equalToSuperview()
         }
-        
+
+        pageContentView.addSubview(pageViewController.view)
         pageViewController.view.snp.makeConstraints {
             $0.size.equalToSuperview()
         }
+
+        pageContentView.addSubview(inquiryButton)
+        inquiryButton.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(90)
+        }
+        
     }
     
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -21,13 +21,11 @@ class SegmentViewController: BaseViewController {
             let direction: UIPageViewController.NavigationDirection = (oldValue <= currentViewNum ? .forward : .reverse)
             pageViewController.setViewControllers([segmentedViewControllers[currentViewNum]], direction: direction, animated: true)
             
-            UIView.animate(withDuration: 0.8) {
+            UIView.animate(withDuration: 0.5) {
                 if self.currentViewNum == 1 {
-                    self.inquiryButton.isHidden = false
-
-                    self.inquiryButton.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 0)
+                    self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 90)
                 } else {
-                    self.inquiryButton.frame = CGRect(x: 0, y: UIScreen.main.bounds.height, width: UIScreen.main.bounds.width, height: 90)
+                    self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: -90)
                 }
             }
         }
@@ -82,8 +80,6 @@ class SegmentViewController: BaseViewController {
         $0.configuration?.baseBackgroundColor = .blue
         $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
-//        $0.frame = CGRect(x: 0, y: UIScreen.main.bounds.height, width: UIScreen.main.bounds.width, height: 90)
-        $0.isHidden = true
         return $0
     }(UIButton(configuration: buttonConfiguration))
     
@@ -91,6 +87,8 @@ class SegmentViewController: BaseViewController {
     
     override func attribute() {
         super.attribute()
+        
+        inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: -90)
         
         setupNavigationTitle()
         setupSegmentedControl()
@@ -141,12 +139,13 @@ class SegmentViewController: BaseViewController {
         view.addSubview(pageContentView)
         pageContentView.snp.makeConstraints {
             $0.top.equalTo(segmentedControl.snp.bottom).offset(12)
-            $0.bottom.width.equalToSuperview()
+            $0.bottom.horizontalEdges.equalToSuperview()
         }
 
         pageContentView.addSubview(pageViewController.view)
         pageViewController.view.snp.makeConstraints {
-            $0.size.equalToSuperview()
+//            $0.size.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
 
         pageContentView.addSubview(inquiryButton)

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -18,7 +18,7 @@ class SegmentViewController: BaseViewController {
     // MARK: - Property
 
     var delegate: SegmentViewControllerDelegate?
-    private var buttonConfiguration = UIButton.Configuration.filled()
+    private var buttonConfiguration = UIButton.Configuration.plain()
     private lazy var segmentedViewControllers: [UIViewController] = [workingView, inquiryView]
     
     private var currentViewNum: Int = 0 {
@@ -30,7 +30,7 @@ class SegmentViewController: BaseViewController {
                 if self.currentViewNum == 1 {
                     self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 90)
                 } else {
-                    self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: -90)
+                    self.inquiryButton.bounds = CGRect(x: 0, y: -90, width: UIScreen.main.bounds.width, height: 90)
                 }
                 self.inquiryButton.isEnabled.toggle()
             }
@@ -96,7 +96,7 @@ class SegmentViewController: BaseViewController {
     override func attribute() {
         super.attribute()
         
-        inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: -90)
+        inquiryButton.bounds = CGRect(x: 0, y: -90, width: UIScreen.main.bounds.width, height: 90)
         
         setupNavigationTitle()
         setupSegmentedControl()
@@ -160,7 +160,6 @@ class SegmentViewController: BaseViewController {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
-        
     }
     
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -160,12 +160,6 @@ class SegmentViewController: BaseViewController {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
-
-        pageContentView.addSubview(inquiryButton)
-        inquiryButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(90)
-        }
     }
 
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -166,13 +166,6 @@ class SegmentViewController: BaseViewController {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
-
-        pageContentView.addSubview(inquiryButton)
-        inquiryButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(90)
-        }
-        
     }
 
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -25,7 +25,7 @@ class SegmentViewController: BaseViewController {
         didSet {
             let direction: UIPageViewController.NavigationDirection = (oldValue <= currentViewNum ? .forward : .reverse)
             pageViewController.setViewControllers([segmentedViewControllers[currentViewNum]], direction: direction, animated: true)
-            
+
             UIView.animate(withDuration: 0.5) {
                 if self.currentViewNum == 1 {
                     self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 90)
@@ -166,6 +166,13 @@ class SegmentViewController: BaseViewController {
             $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(90)
         }
+
+        pageContentView.addSubview(inquiryButton)
+        inquiryButton.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.height.equalTo(90)
+        }
+        
     }
 
     private func setupSegmentedControl() {

--- a/GiwazipClient/Views/SegmentViewController.swift
+++ b/GiwazipClient/Views/SegmentViewController.swift
@@ -14,7 +14,7 @@ protocol SegmentViewControllerDelegate {
 }
 
 class SegmentViewController: BaseViewController {
-    
+
     // MARK: - Property
 
     var delegate: SegmentViewControllerDelegate?


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 버튼 애니메이션 추가하기 위함
- 네비게이션 추가하기 위함(Coordinator)
- 일부 셀 레이아웃 에러를 바로잡기 위함.

## Key Changes 🔥 (주요 구현/변경 사항)
- [x] 시공내역 탭일 때 버튼 내려가게
- [x] 문의내역 탭일 때 버튼이 올라오게
- [x] 버튼 클릭 시 FullScreen Modal
- [x] 셀 레이아웃 수정

## ScreenShot 📷 (참고 사진)
https://user-images.githubusercontent.com/98405970/216266493-3070769c-aec6-48f9-a923-f7d5217894f1.mp4


## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 코드자체는 간단하지만, 일부 셀 레이아웃에 대한 ambiguous error가 있어 해당 부분에 대해 수정하였습니다.
```swift
if self.currentViewNum == 1 {
    self.inquiryButton.bounds = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 90)
} else {
    self.inquiryButton.bounds = CGRect(x: 0, y: -90, width: UIScreen.main.bounds.width, height: 90)
}

pageContentView.addSubview(inquiryButton)
inquiryButton.snp.makeConstraints {
    $0.horizontalEdges.bottom.equalToSuperview()
    $0.height.equalTo(90)
}
```
- layout으로 `heightAnchor = 90`으로 잡았기 때문에, `height = 90`인 `inquiryButton`의 좌상단을 기준으로 (0,0)좌표를 가짐.
- 또한 `inquiryButton`의 bottom Constraint가 view.bottom을 기준으로 `height = 90`을 잡았기 때문에, origin좌표는 변하지 않음
- `inquiryButton`의 y축 -90만큼 내려 버튼이 내려가는 동작 구현
- `inquiryButton`의 y축을 0으로 돌려 버튼이 올라가는 동작 구현
  - y축을 -90내려도 실제 constraint는 bottom기준 height = 90을 받고 있기 때문에, isEnable = false를 하지않으면 보이지 않더라도 버튼동작이 가능함. 따라서 `isEnable.toggle`이 반영됨.
  - `currentViewNum == 0`일 때, bounds에서 `y= 0` `height= -90`으로 하여도 동작은 동일하지만, hierarchy를 보면 y값이 -90, height = 90으로, 실제는 y축이 변동되기 때문에 height를 변경하지 않고 y축을 변경하였음.

- frame이 아닌 bounds를 사용한 이유는, 
  - frame은 `inquiryButton`의 superView 즉 view의 기준좌표(0, 0)를 기준으로 하지만,
  - bounds는 `inquiryButton` 본인의 기준좌표(0, 0)을 기준으로 하기 때문에 bounds를 사용해야 정상동작 구현이 가능.

- 설명 오류이거나 잘못된 코드라면 리뷰 남겨주시면 감사함:) :) :)

## Reference 🔗
- [Animation](https://jinnify.tistory.com/66)

## Close Issues 🔒 (닫을 Issue)
Close #32.
