### PR TITLE
[Fix] 뷰 스크롤시 진행률이 첫번째로 돌아가는 문제 외 1개 문제 해결

### DIFF
--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -14,6 +14,7 @@ class HistoryViewController: BaseViewController {
     // MARK: - Property
 
     var isWorkView = true
+    private var isFirstVisit = true
 
     // MARK: - View
 
@@ -113,8 +114,9 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
             cell.progress = CGFloat((indexPath.item % 11) * 10)
             cell.categoryName.text = "안방"
 
-            if indexPath.item == 0 {
+            if indexPath.item == 0 && isFirstVisit {
                 collectionView.selectItem(at: indexPath, animated: true, scrollPosition: .init())
+                isFirstVisit.toggle()
             }
 
             return cell

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -46,6 +46,7 @@ class HistoryViewController: BaseViewController {
         historyCollectionView.register(HistoryCell.self, forCellWithReuseIdentifier: HistoryCell.identifier)
 
         historyCollectionView.showsVerticalScrollIndicator = false
+        historyCollectionView.allowsMultipleSelection = true
     }
 
     override func layout() {
@@ -140,5 +141,11 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 0
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        (historyCollectionView.indexPathsForSelectedItems ?? [])
+            .filter { $0.section == indexPath.section && $0.item != indexPath.item }
+            .forEach { self.historyCollectionView.deselectItem(at: $0, animated: false) }
     }
 }

--- a/GiwazipClient/Views/HistoryViewController.swift
+++ b/GiwazipClient/Views/HistoryViewController.swift
@@ -150,4 +150,10 @@ extension HistoryViewController: UICollectionViewDelegate, UICollectionViewDataS
             .filter { $0.section == indexPath.section && $0.item != indexPath.item }
             .forEach { self.historyCollectionView.deselectItem(at: $0, animated: false) }
     }
+
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        if (historyCollectionView.indexPathsForSelectedItems ?? []).filter({ $0.section == 0 }).isEmpty {
+            historyCollectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+        }
+    }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 뷰를 아래로 스크롤 한 뒤 위로 돌아오면 선택한 카테고리가 첫번째 카테고리로 돌아가는 문제를 해결하기 위함
- 게시물을 클릭하면 선택된 카테고리가 취소되는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- select item을 section당 한개 선택 가능하도록 변경
- 처음 뷰에 들어왔을 때만, 첫번째 아이템이 선택되어 있도록 변경

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/220218436-a53ca649-fb64-4187-9634-d050c3d7eb76.gif">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 카테고리 부분에서 문제가 있던 것을 수정했습니다.
- 생각보다 어려운 코드는 아니었는데, 약간의 트릭 코드인 것 같아서 썩 맘에 드는 편은 아니네요..
- 짧은 코드이니 가볍게 살펴보셔도 좋습니다만, 잘못된 동작이 없나 잘 확인 부탁드려요.
- rebase 버그로 기존 PR 클로즈 후 새로 열었습니다.

## Reference 🔗
- [stackoverflow - iOS UICollectionView cell selection per section](https://stackoverflow.com/questions/15372940/ios-uicollectionview-cell-selection-per-section)

## Close Issues 🔒 (닫을 Issue)
- Close #47.
