### PR TITLE
[Feature] NetworkManager (Put, Post) 기능 추가

### DIFF
--- a/GiwazipClient/Models/NetworkResult.swift
+++ b/GiwazipClient/Models/NetworkResult.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum NetworkResult<T> {
     case success(T)
-    case reqError
+    case notFound
     case connectionFail
     case serverError
     case networkFail

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -29,7 +29,7 @@ final class NetworkManager {
 //        loadRoomData(url: APIEnvironment.roomsURL + "/user/1")
     }
 
-    // MARK: - Load Data
+    // MARK: - Get
     
     private func loadUserData(url: String) {
         _ = requestData(url: url, type: User.self)
@@ -67,6 +67,57 @@ final class NetworkManager {
                     print("This is networkFail")
                 }
             }
+    }
+    
+    // MARK: - Post
+    
+    func uploadUserData(number: String) {
+        _ = uploadData(url: APIEnvironment.usersURL, number: number, type: User.self)
+            .bind { status in
+                switch status {
+                case .success(let number):
+                    guard let number = number as? User else { return }
+                    self.userData = number
+                case .connectionFail:
+                    print("This is connectionFail")
+                case .reqError:
+                    print("This is requestError")
+                case .serverError:
+                    print("This is serverError")
+                case .networkFail:
+                    print("This is networkFail")
+                }
+            }
+    }
+    
+    func makeParameter(number: String) -> Parameters {
+        return ["number": number]
+    }
+    
+    func uploadData<T: Decodable>(url: String, number: String, type: T.Type) -> Observable<NetworkResult<Any>> {
+        return Observable.create() { observer in
+            AF.request(url,
+                       method: .post,
+                       parameters: self.makeParameter(number: number),
+                       encoding: JSONEncoding.default,
+                       headers: self.header)
+              .responseData { (response) in
+                  switch response.result {
+                  case .success:
+                      guard let data = response.data,
+                            let statusCode = response.response?.statusCode
+                      else { return }
+
+                      let networkResult = self.judgeStatus(by: statusCode,
+                                                           self.isValidData(data: data, type: T.self))
+                      observer.onNext(networkResult)
+                      observer.onCompleted()
+                  case .failure:
+                      break
+                  }
+              }
+            return Disposables.create()
+        }
     }
 
     // MARK: - Network Request

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -116,57 +116,6 @@ final class NetworkManager {
                 }
             }
     }
-    
-    // MARK: - Post
-    
-    func uploadUserData(number: String) {
-        _ = uploadData(url: APIEnvironment.usersURL, number: number, type: User.self)
-            .bind { status in
-                switch status {
-                case .success(let number):
-                    guard let number = number as? User else { return }
-                    self.userData = number
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .reqError:
-                    print("This is requestError")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
-    }
-    
-    func makeParameter(number: String) -> Parameters {
-        return ["number": number]
-    }
-    
-    func uploadData<T: Decodable>(url: String, number: String, type: T.Type) -> Observable<NetworkResult<Any>> {
-        return Observable.create() { observer in
-            AF.request(url,
-                       method: .post,
-                       parameters: self.makeParameter(number: number),
-                       encoding: JSONEncoding.default,
-                       headers: self.header)
-              .responseData { (response) in
-                  switch response.result {
-                  case .success:
-                      guard let data = response.data,
-                            let statusCode = response.response?.statusCode
-                      else { return }
-
-                      let networkResult = self.judgeStatus(by: statusCode,
-                                                           self.isValidData(data: data, type: T.self))
-                      observer.onNext(networkResult)
-                      observer.onCompleted()
-                  case .failure:
-                      break
-                  }
-              }
-            return Disposables.create()
-        }
-    }
 
     // MARK: - Network Request
 

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -40,8 +40,8 @@ final class NetworkManager {
                     self.userData = userData
                 case .connectionFail:
                     print("This is connectionFail")
-                case .reqError:
-                    print("This is requestError")
+                case .notFound:
+                    print("This is notFound")
                 case .serverError:
                     print("This is serverError")
                 case .networkFail:
@@ -59,8 +59,8 @@ final class NetworkManager {
                     self.roomData = roomData
                 case .connectionFail:
                     print("This is connectionFail")
-                case .reqError:
-                    print("This is requestError")
+                case .notFound:
+                    print("This is notFound")
                 case .serverError:
                     print("This is serverError")
                 case .networkFail:
@@ -80,8 +80,8 @@ final class NetworkManager {
                     self.userData = number
                 case .connectionFail:
                     print("This is connectionFail")
-                case .reqError:
-                    print("This is requestError")
+                case .notFound:
+                    print("This is notFound")
                 case .serverError:
                     print("This is serverError")
                 case .networkFail:
@@ -151,7 +151,7 @@ final class NetworkManager {
         switch statusCode {
         case 200: return networkResult
         case 403: return .connectionFail
-        case 404: return .reqError
+        case 404: return .notFound
         case 500: return .serverError
         default: return .networkFail
         }
@@ -160,7 +160,7 @@ final class NetworkManager {
     private func isValidData<T: Decodable>(data: Data, type: T.Type) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let data = try? decoder.decode(type, from: data)
-        else { return .reqError }
+        else { return .notFound }
         return .success(data)
     }
 }

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -116,6 +116,57 @@ final class NetworkManager {
                 }
             }
     }
+    
+    // MARK: - Post
+    
+    func uploadUserData(number: String) {
+        _ = uploadData(url: APIEnvironment.usersURL, number: number, type: User.self)
+            .bind { status in
+                switch status {
+                case .success(let number):
+                    guard let number = number as? User else { return }
+                    self.userData = number
+                case .connectionFail:
+                    print("This is connectionFail")
+                case .reqError:
+                    print("This is requestError")
+                case .serverError:
+                    print("This is serverError")
+                case .networkFail:
+                    print("This is networkFail")
+                }
+            }
+    }
+    
+    func makeParameter(number: String) -> Parameters {
+        return ["number": number]
+    }
+    
+    func uploadData<T: Decodable>(url: String, number: String, type: T.Type) -> Observable<NetworkResult<Any>> {
+        return Observable.create() { observer in
+            AF.request(url,
+                       method: .post,
+                       parameters: self.makeParameter(number: number),
+                       encoding: JSONEncoding.default,
+                       headers: self.header)
+              .responseData { (response) in
+                  switch response.result {
+                  case .success:
+                      guard let data = response.data,
+                            let statusCode = response.response?.statusCode
+                      else { return }
+
+                      let networkResult = self.judgeStatus(by: statusCode,
+                                                           self.isValidData(data: data, type: T.self))
+                      observer.onNext(networkResult)
+                      observer.onCompleted()
+                  case .failure:
+                      break
+                  }
+              }
+            return Disposables.create()
+        }
+    }
 
     // MARK: - Network Request
 

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -92,9 +92,9 @@ final class NetworkManager {
                 }
             }
     }
-    
+
     // MARK: - Put
-    
+
     func updateUserData(number: String) {
         _ = requestData(url: APIEnvironment.usersURL + "/2",
                         httpMethod: .put,
@@ -116,9 +116,9 @@ final class NetworkManager {
                 }
             }
     }
-    
+
     // MARK: - Network Request
-    
+
     private func makeParameter(number: String) -> Parameters {
         return ["number": number]
     }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 유저 정보 추가, 수정 기능을 가능토록 하기 위함.

## Key Changes 🔥 (주요 구현/변경 사항)
- 유저 정보(전화번호) 추가 기능
- 유저 정보(전화번호) 수정 기능

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 고객앱에는 user는 user정보 추가, 수정만 필요하고,
- 문의를 위한 게시물 추가, 수정 기능이 필요하지만, API명세에 게시물 파트는 아직 미완성이므로, user정보와 관련된 부분을 우선 완료하였습니다.
- 구독코드를 .subscribe에서 .bind로 수정하였습니다.
  - 이유는 모두 networkResult에서 서버통신간 발생하는 에러를 명시하고 있으며, 통신 에러 코드도 아래와 같이 받고 있기 때문에, 별도의 에러 처리를 할 필요가 없다 생각해, subscribe의 onNext만을 받는 bind를 사용하는게 용도에 어울린다 생각했습니다.
```swift
                switch status {
                case .success(let userData):
                    guard let userData = userData as? User else { return }
                    self.userData = userData
                case .connectionFail:
                    print("This is connectionFail")
                case .notFound:
                    print("This is notFound")
                case .serverError:
                    print("This is serverError")
                case .networkFail:
                    print("This is networkFail")
                }
```
 - HTTPMethod 기본형식은 아직까지 get이 가장 많아 .get을 기본으로 하였고, post와 put은 필요 시 매개변수를 작성하는 방식으로 하였습니다.
<img width="787" alt="Screenshot 2023-02-22 at 4 21 21 PM" src="https://user-images.githubusercontent.com/98405970/220550551-024f6668-e379-4085-92ef-6bd33394d18b.png">

- post와 put 호출방식은 기존과 동일하게 NetworkManager.shared(=viewModel).post or put함수를 사용하려는 viewController에서 호출 후, 생성, 수정하고자 하는 데이터를 반영하면 쉽게 사용할 수 있습니다.
```swift
        viewModel.uploadUserData(number: "123456789") // post
        viewModel.updateUserData(number: "98765432") // put
```
## Reference 🔗
[둥찬 - Alamofire Post](https://seungchan.tistory.com/entry/4주차-세미나-Alamofire-POST)
[Money Driven Developer - Alamofire iOS통신](https://kor45cw.tistory.com/294)

## Close Issues 🔒 (닫을 Issue)
Close #36.
