### PR TITLE
[Feature] NetworkManager 게시물 post 및 코드 스타일 수정

### DIFF
--- a/GiwazipClient.xcodeproj/project.pbxproj
+++ b/GiwazipClient.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		438E5B2A297982E300FD947E /* HideKeyboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438E5B29297982E300FD947E /* HideKeyboard+.swift */; };
 		43997B052981367200C5A163 /* PostImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43997B042981367200C5A163 /* PostImageViewController.swift */; };
 		43E1F565297A16CD000A13D4 /* Alert+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E1F564297A16CD000A13D4 /* Alert+.swift */; };
-		98197C0C29A264AC008C4C55 /* APIEnvironmnet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98197C0B29A264AC008C4C55 /* APIEnvironmnet.swift */; };
+		98197C0C29A264AC008C4C55 /* APIEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98197C0B29A264AC008C4C55 /* APIEnvironment.swift */; };
 		98197C0E29A264CA008C4C55 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98197C0D29A264CA008C4C55 /* NetworkResult.swift */; };
 		98197C1029A26562008C4C55 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98197C0F29A26562008C4C55 /* NetworkManager.swift */; };
 		9839F36F298B55350058639F /* SegmentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9839F36E298B55350058639F /* SegmentCoordinator.swift */; };
@@ -79,7 +79,7 @@
 		43997B042981367200C5A163 /* PostImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostImageViewController.swift; sourceTree = "<group>"; };
 		43E1F564297A16CD000A13D4 /* Alert+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+.swift"; sourceTree = "<group>"; };
 		8F07A553ABFFB36AAAC61128 /* Pods-GiwazipClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GiwazipClient.release.xcconfig"; path = "Target Support Files/Pods-GiwazipClient/Pods-GiwazipClient.release.xcconfig"; sourceTree = "<group>"; };
-		98197C0B29A264AC008C4C55 /* APIEnvironmnet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEnvironmnet.swift; sourceTree = "<group>"; };
+		98197C0B29A264AC008C4C55 /* APIEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEnvironment.swift; sourceTree = "<group>"; };
 		98197C0D29A264CA008C4C55 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		98197C0F29A26562008C4C55 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		9839F36E298B55350058639F /* SegmentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentCoordinator.swift; sourceTree = "<group>"; };
@@ -119,7 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				260A63C929710725004034AD /* Models.swift */,
-				98197C0B29A264AC008C4C55 /* APIEnvironmnet.swift */,
+				98197C0B29A264AC008C4C55 /* APIEnvironment.swift */,
 				98197C0D29A264CA008C4C55 /* NetworkResult.swift */,
 			);
 			path = Models;
@@ -414,7 +414,7 @@
 				43997B052981367200C5A163 /* PostImageViewController.swift in Sources */,
 				260A63E229710846004034AD /* MainCoordinator.swift in Sources */,
 				98197C1029A26562008C4C55 /* NetworkManager.swift in Sources */,
-				98197C0C29A264AC008C4C55 /* APIEnvironmnet.swift in Sources */,
+				98197C0C29A264AC008C4C55 /* APIEnvironment.swift in Sources */,
 				98419D76297C1BF9005E0EF6 /* PostingPhotoCell.swift in Sources */,
 				260A63E829710A7F004034AD /* SubCoordinator.swift in Sources */,
 				26B7B11E29A3A2C900D3C3F7 /* ColorLiteral.swift in Sources */,

--- a/GiwazipClient/Literals/TextLiteral.swift
+++ b/GiwazipClient/Literals/TextLiteral.swift
@@ -92,4 +92,12 @@ enum TextLiteral {
     // MARK: - ASCell
 
     static let remainText = "남았어요"
+    
+    // MARK: - NetworkManager
+    
+    static let badRequest = "This is badRequest"
+    static let connectionFail = "This is connectionFail"
+    static let notFound = "This is notFound"
+    static let serverError = "This is serverError"
+    static let networkFail = "This is networkFail"
 }

--- a/GiwazipClient/Literals/TextLiteral.swift
+++ b/GiwazipClient/Literals/TextLiteral.swift
@@ -92,12 +92,4 @@ enum TextLiteral {
     // MARK: - ASCell
 
     static let remainText = "남았어요"
-    
-    // MARK: - NetworkManager
-    
-    static let badRequest = "This is badRequest"
-    static let connectionFail = "This is connectionFail"
-    static let notFound = "This is notFound"
-    static let serverError = "This is serverError"
-    static let networkFail = "This is networkFail"
 }

--- a/GiwazipClient/Models/NetworkResult.swift
+++ b/GiwazipClient/Models/NetworkResult.swift
@@ -9,9 +9,10 @@ import Foundation
 
 enum NetworkResult<T> {
     case success(T)
-    case badRequest
-    case notFound
-    case connectionFail
-    case serverError
+    case badRequest(T)
+    case notFound(T)
+    case connectionFail(T)
+    case serverError(T)
     case networkFail
+    case decodingError
 }

--- a/GiwazipClient/Models/NetworkResult.swift
+++ b/GiwazipClient/Models/NetworkResult.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum NetworkResult<T> {
     case success(T)
+    case badRequest
     case notFound
     case connectionFail
     case serverError

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -19,11 +19,11 @@ final class NetworkManager {
 
     private init() {
         // TODO: 그때그때 방 번호가 달라져야 함!
-        loadOrCreateData(url: APIEnvironment.usersURL + "/room/1", type: User.self) { [weak self] data in
-            self?.userData = data
+        loadOrCreateData(url: APIEnvironment.usersURL + "/room/1", type: User.self) { data in
+            self.userData = data
         }
-        loadOrCreateData(url: APIEnvironment.roomsURL + "/1", type: Room.self) { [weak self] data in
-            self?.roomData = data
+        loadOrCreateData(url: APIEnvironment.roomsURL + "/1", type: Room.self) { data in
+            self.roomData = data
         }
     }
 
@@ -32,31 +32,31 @@ final class NetworkManager {
                                         parameters: Parameters? = nil,
                                         type: T.Type,
                                         completion: @escaping (T) -> Void) {
-        let requestedData = requestData(url: url,
+        let responseData = requestData(url: url,
                                         httpMethod: httpMethod,
                                         parameters: parameters,
                                         type: type)
-        checkStatus(requestData: requestedData) { data in
+        checkStatus(responseData) { data in
             completion(data)
         }
     }
 
     func uploadPostData(description: String, files: [Data]) {
-        let requestedUploadPost = requestUploadData(userID: 3,
+        let responseData = requestUploadData(userID: 3,
                                                     roomID: 1,
                                                     categoryID: 1,
                                                     description: description,
                                                     files: files,
                                                     url: APIEnvironment.postsURL + "/photo",
                                                     type: Post.self)
-        checkStatus(requestData: requestedUploadPost) { [weak self] data in
-            self?.roomData = data
+        checkStatus(responseData) { data in
+            self.roomData = data
         }
     }
     
-    private func checkStatus<T>(requestData: Observable<NetworkResult<Any>>,
+    private func checkStatus<T>(_ responseData: Observable<NetworkResult<Any>>,
                                 completion: @escaping (T) -> Void) {
-        requestData.bind { status in
+        responseData.bind { status in
             switch status {
             case .success(let data):
                 guard let data = data as? T else { return }
@@ -150,18 +150,6 @@ final class NetworkManager {
     }
 
     // MARK: - Check Server Data
-    
-//    private func judgeStatus(by statusCode: Int,
-//                             _ networkResult: NetworkResult<Any>) -> NetworkResult<Any> {
-//        switch statusCode {
-//        case 200: return networkResult
-//        case 400: return .badRequest
-//        case 403: return .connectionFail
-//        case 404: return .notFound
-//        case 500: return .serverError
-//        default: return .networkFail
-//        }
-//    }
 
     private func isValidData<T: Decodable>(data: Data,
                                            type: T.Type,

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -19,11 +19,11 @@ final class NetworkManager {
 
     private init() {
         // TODO: 그때그때 방 번호가 달라져야 함!
-        loadOrCreateData(url: APIEnvironment.usersURL + "/room/1", type: User.self) { data in
-            self.userData = data
+        loadOrCreateData(url: APIEnvironment.usersURL + "/room/1", type: User.self) { [weak self] data in
+            self?.userData = data
         }
-        loadOrCreateData(url: APIEnvironment.roomsURL + "/1", type: Room.self) { data in
-            self.roomData = data
+        loadOrCreateData(url: APIEnvironment.roomsURL + "/1", type: Room.self) { [weak self] data in
+            self?.roomData = data
         }
     }
 
@@ -49,8 +49,8 @@ final class NetworkManager {
                                                     files: files,
                                                     url: APIEnvironment.postsURL + "/photo",
                                                     type: Post.self)
-        checkStatus(requestData: requestedUploadPost) { data in
-            self.roomData = data
+        checkStatus(requestData: requestedUploadPost) { [weak self] data in
+            self?.roomData = data
         }
     }
     

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -16,66 +16,69 @@ final class NetworkManager {
     private let header: HTTPHeaders = [APIEnvironment.apiField: APIEnvironment.apiKey]
     var userData: User?
     var roomData: Room?
-    var postData: Post?
 
     private init() {
         // TODO: 그때그때 방 번호가 달라져야 함!
-//        loadUserData(url: APIEnvironment.usersURL + "/1")
-        loadUserData(url: APIEnvironment.usersURL + "/room/1")
-        
-        loadRoomData(url: APIEnvironment.roomsURL + "/1")
-//        loadRoomData(url: APIEnvironment.roomsURL + "/category/1")
-//        loadRoomData(url: APIEnvironment.roomsURL + "/post/1")
-//        loadRoomData(url: APIEnvironment.roomsURL + "/post-category/1")
-//        loadRoomData(url: APIEnvironment.roomsURL + "/user/1")
+        loadOrCreateData(url: APIEnvironment.usersURL + "/room/1", type: User.self) { data in
+            self.userData = data
+        }
+        loadOrCreateData(url: APIEnvironment.roomsURL + "/1", type: Room.self) { data in
+            self.roomData = data
+        }
     }
 
-    // MARK: - Get
-    
-    func loadUserData(url: String) {
-        let requestedData = requestData(url: url, type: User.self)
-        checkUserStatus(requestData: requestedData)
+    func loadOrCreateData<T: Decodable>(url: String,
+                                httpMethod: HTTPMethod = .get,
+                                parameters: Parameters? = nil,
+                                type: T.Type,
+                                completion: @escaping(T) -> Void) {
+        let requestedData = requestData(url: url,
+                                        httpMethod: httpMethod,
+                                        parameters: parameters,
+                                        type: type)
+        checkStatus(requestData: requestedData) { data in
+            completion(data)
+        }
     }
 
-    func loadRoomData(url: String) {
-        let requestedData = requestData(url: url, type: Room.self)
-        checkRoomStatus(requestData: requestedData)
-    }
-    
-    // MARK: - Post
-    
-    func createUserData(number: String) {
-        let requestedData = requestData(url: APIEnvironment.usersURL,
-                        httpMethod: .post,
-                        parameters: makeParameter(number: number),
-                        type: User.self)
-        checkUserStatus(requestData: requestedData)
-    }
-    
     func uploadPostData(description: String, files: [Data]) {
-        let requestedUploadPost = requestUploadData(userID: 3, roomID: 1,
-                              categoryID: 1, description: description,
-                              files: files, url: APIEnvironment.postsURL + "/photo",
-                              type: Post.self)
-        checkPostStatus(requestData: requestedUploadPost)
+        let requestedUploadPost = requestUploadData(userID: 3,
+                                                    roomID: 1,
+                                                    categoryID: 1,
+                                                    description: description,
+                                                    files: files,
+                                                    url: APIEnvironment.postsURL + "/photo",
+                                                    type: Post.self)
+        checkStatus(requestData: requestedUploadPost) { data in
+            self.roomData = data
+        }
     }
-
-    // MARK: - Put
-
-    func updateUserData(number: String) {
-        let requestedData = requestData(url: APIEnvironment.usersURL + "/2",
-                        httpMethod: .put,
-                        parameters: makeParameter(number: number),
-                        type: User.self)
-        checkUserStatus(requestData: requestedData)
+    
+    private func checkStatus<T>(requestData: Observable<NetworkResult<Any>>,
+                        completion: @escaping (T) -> Void) {
+        requestData.bind { status in
+            switch status {
+            case .success(let data):
+                guard let data = data as? T else { return }
+                completion(data)
+            case .badRequest:
+                print(TextLiteral.badRequest)
+            case .connectionFail:
+                print(TextLiteral.connectionFail)
+            case .notFound:
+                print(TextLiteral.notFound)
+            case .serverError:
+                print(TextLiteral.serverError)
+            case .networkFail:
+                print(TextLiteral.networkFail)
+            }
+        }
     }
 
     // MARK: - Network Request
-
-    private func makeParameter(number: String) -> Parameters { return ["number": number] }
     
     private func requestData<T: Decodable>(url: String,
-                                           httpMethod: HTTPMethod = .get,
+                                           httpMethod: HTTPMethod,
                                            parameters: Parameters? = nil,
                                            type: T.Type) -> Observable<NetworkResult<Any>> {
         return Observable.create() { observer in
@@ -90,10 +93,14 @@ final class NetworkManager {
         }
     }
     
-    func requestUploadData<T: Decodable> (userID: Int, roomID: Int,
-                                          categoryID: Int, description: String,
-                                          files: [Data], url: String,
-                                          httpMethod: HTTPMethod = .post, type: T.Type) -> Observable<NetworkResult<Any>> {
+    private func requestUploadData<T: Decodable> (userID: Int,
+                                          roomID: Int,
+                                          categoryID: Int,
+                                          description: String,
+                                          files: [Data],
+                                          url: String,
+                                          httpMethod: HTTPMethod = .post,
+                                          type: T.Type) -> Observable<NetworkResult<Any>> {
         return Observable.create() { observer in
             let header: HTTPHeaders = ["Content-Type": "multipart/form-data",
                                        APIEnvironment.apiField: APIEnvironment.apiKey]
@@ -102,12 +109,12 @@ final class NetworkManager {
                                              "categoryID": categoryID,
                                              "description": description,
                                              "files": files]
-            
+
             let dataUpload = AF.upload(multipartFormData: { multipartFormData in
                 for (key, value) in parameters {
                     multipartFormData.append("\(value)".data(using: .utf8)!, withName: key)
                 }
-                
+
                 for i in 0..<files.count {
                     let photo = files[i]
                     multipartFormData.append(photo,
@@ -115,15 +122,15 @@ final class NetworkManager {
                                              fileName: "\(userID)0\(i + 1).png")
                 }
             },to: url, usingThreshold: UInt64.init(), method: httpMethod, headers: header)
-            
+
             self.checkResponseData(request: dataUpload, type: type, observer: observer)
             return Disposables.create()
         }
     }
-    
+
     // MARK: - Network Response
-    
-    func checkResponseData<T: Decodable>(request: DataRequest,
+
+    private func checkResponseData<T: Decodable>(request: DataRequest,
                                          type: T.Type,
                                          observer: AnyObserver<NetworkResult<Any>>) {
         request.responseData { response in
@@ -132,7 +139,7 @@ final class NetworkManager {
                 guard let data = response.data,
                       let statusCode = response.response?.statusCode
                 else { return }
-                
+
                 let networkResult = self.judgeStatus(by: statusCode,
                                                      self.isValidData(data: data, type: T.self))
                 observer.onNext(networkResult)
@@ -142,73 +149,14 @@ final class NetworkManager {
             }
         }
     }
-    
-    // TODO: - bind closure 안에서 inout 등 사용법 찾으면 한 함수로 수정(checkStatus)
-    func checkUserStatus(requestData: Observable<NetworkResult<Any>>){
-        requestData.bind { status in
-            switch status {
-            case .success(let data):
-                guard let data = data as? User else { return }
-                self.userData = data
-            case .badRequest:
-                print(TextLiteral.badRequest)
-            case .connectionFail:
-                print(TextLiteral.connectionFail)
-            case .notFound:
-                print(TextLiteral.notFound)
-            case .serverError:
-                print(TextLiteral.serverError)
-            case .networkFail:
-                print(TextLiteral.networkFail)
-            }
-        }
-    }
-    
-    func checkRoomStatus(requestData: Observable<NetworkResult<Any>>) {
-        requestData.bind { status in
-            switch status {
-            case .success(let data):
-                guard let data = data as? Room else { return }
-                self.roomData = data
-            case .badRequest:
-                print(TextLiteral.badRequest)
-            case .connectionFail:
-                print(TextLiteral.connectionFail)
-            case .notFound:
-                print(TextLiteral.notFound)
-            case .serverError:
-                print(TextLiteral.serverError)
-            case .networkFail:
-                print(TextLiteral.networkFail)
-            }
-        }
-    }
-    
-    func checkPostStatus(requestData: Observable<NetworkResult<Any>>) {
-        requestData.bind { status in
-            switch status {
-            case .success(let data):
-                guard let data = data as? Post else { return }
-                self.postData = data
-            case .badRequest:
-                print(TextLiteral.badRequest)
-            case .connectionFail:
-                print(TextLiteral.connectionFail)
-            case .notFound:
-                print(TextLiteral.notFound)
-            case .serverError:
-                print(TextLiteral.serverError)
-            case .networkFail:
-                print(TextLiteral.networkFail)
-            }
-        }
-    }
 
     // MARK: - Check Server Data
     
-    private func judgeStatus(by statusCode: Int, _ networkResult: NetworkResult<Any>) -> NetworkResult<Any> {
+    private func judgeStatus(by statusCode: Int,
+                             _ networkResult: NetworkResult<Any>) -> NetworkResult<Any> {
         switch statusCode {
         case 200: return networkResult
+        case 400: return .badRequest
         case 403: return .connectionFail
         case 404: return .notFound
         case 500: return .serverError
@@ -216,7 +164,8 @@ final class NetworkManager {
         }
     }
 
-    private func isValidData<T: Decodable>(data: Data, type: T.Type) -> NetworkResult<Any> {
+    private func isValidData<T: Decodable>(data: Data,
+                                           type: T.Type) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let data = try? decoder.decode(type, from: data)
         else { return .notFound }

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -74,6 +74,57 @@ final class NetworkManager {
             }
         }
     }
+    
+    // MARK: - Post
+    
+    func uploadUserData(number: String) {
+        _ = uploadData(url: APIEnvironment.usersURL, number: number, type: User.self)
+            .bind { status in
+                switch status {
+                case .success(let number):
+                    guard let number = number as? User else { return }
+                    self.userData = number
+                case .connectionFail:
+                    print("This is connectionFail")
+                case .reqError:
+                    print("This is requestError")
+                case .serverError:
+                    print("This is serverError")
+                case .networkFail:
+                    print("This is networkFail")
+                }
+            }
+    }
+    
+    func makeParameter(number: String) -> Parameters {
+        return ["number": number]
+    }
+    
+    func uploadData<T: Decodable>(url: String, number: String, type: T.Type) -> Observable<NetworkResult<Any>> {
+        return Observable.create() { observer in
+            AF.request(url,
+                       method: .post,
+                       parameters: self.makeParameter(number: number),
+                       encoding: JSONEncoding.default,
+                       headers: self.header)
+              .responseData { (response) in
+                  switch response.result {
+                  case .success:
+                      guard let data = response.data,
+                            let statusCode = response.response?.statusCode
+                      else { return }
+
+                      let networkResult = self.judgeStatus(by: statusCode,
+                                                           self.isValidData(data: data, type: T.self))
+                      observer.onNext(networkResult)
+                      observer.onCompleted()
+                  case .failure:
+                      break
+                  }
+              }
+            return Disposables.create()
+        }
+    }
 
     // MARK: - Network Request
     

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -69,57 +69,6 @@ final class NetworkManager {
                         type: User.self)
         checkUserStatus(requestData: requestedData)
     }
-    
-    // MARK: - Post
-    
-    func uploadUserData(number: String) {
-        _ = uploadData(url: APIEnvironment.usersURL, number: number, type: User.self)
-            .bind { status in
-                switch status {
-                case .success(let number):
-                    guard let number = number as? User else { return }
-                    self.userData = number
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .reqError:
-                    print("This is requestError")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
-    }
-    
-    func makeParameter(number: String) -> Parameters {
-        return ["number": number]
-    }
-    
-    func uploadData<T: Decodable>(url: String, number: String, type: T.Type) -> Observable<NetworkResult<Any>> {
-        return Observable.create() { observer in
-            AF.request(url,
-                       method: .post,
-                       parameters: self.makeParameter(number: number),
-                       encoding: JSONEncoding.default,
-                       headers: self.header)
-              .responseData { (response) in
-                  switch response.result {
-                  case .success:
-                      guard let data = response.data,
-                            let statusCode = response.response?.statusCode
-                      else { return }
-
-                      let networkResult = self.judgeStatus(by: statusCode,
-                                                           self.isValidData(data: data, type: T.self))
-                      observer.onNext(networkResult)
-                      observer.onCompleted()
-                  case .failure:
-                      break
-                  }
-              }
-            return Disposables.create()
-        }
-    }
 
     // MARK: - Network Request
 

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -16,6 +16,7 @@ final class NetworkManager {
     private let header: HTTPHeaders = [APIEnvironment.apiField: APIEnvironment.apiKey]
     var userData: User?
     var roomData: Room?
+    var postData: Post?
 
     private init() {
         // TODO: 그때그때 방 번호가 달라져야 함!
@@ -32,41 +33,13 @@ final class NetworkManager {
     // MARK: - Get
     
     func loadUserData(url: String) {
-        _ = requestData(url: url, type: User.self)
-            .bind { status in
-                switch status {
-                case .success(let userData):
-                    guard let userData = userData as? User else { return }
-                    self.userData = userData
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .notFound:
-                    print("This is notFound")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
+        let requestedData = requestData(url: url, type: User.self)
+        checkUserStatus(requestData: requestedData)
     }
 
     func loadRoomData(url: String) {
-        _ = requestData(url: url, type: Room.self)
-            .bind { status in
-                switch status {
-                case .success(let roomData):
-                    guard let roomData = roomData as? Room else { return }
-                    self.roomData = roomData
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .notFound:
-                    print("This is notFound")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
+        let requestedData = requestData(url: url, type: Room.self)
+        checkRoomStatus(requestData: requestedData)
     }
     
     // MARK: - Post
@@ -76,45 +49,25 @@ final class NetworkManager {
                         httpMethod: .post,
                         parameters: makeParameter(number: number),
                         type: User.self)
-            .bind { status in
-                switch status {
-                case .success(let userData):
-                    guard let userData = userData as? User else { return }
-                    self.userData = userData
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .notFound:
-                    print("This is notFound")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
+        checkUserStatus(requestData: requestedData)
+    }
+    
+    func uploadPostData(description: String, files: [Data]) {
+        let requestedUploadPost = requestUploadPost(userID: 3, roomID: 1,
+                              categoryID: 1, description: description,
+                              files: files, url: APIEnvironment.postsURL + "/photo",
+                              type: Post.self)
+        checkPostStatus(requestData: requestedUploadPost)
     }
 
     // MARK: - Put
 
     func updateUserData(number: String) {
-        _ = requestData(url: APIEnvironment.usersURL + "/2",
+        let requestedData = requestData(url: APIEnvironment.usersURL + "/2",
                         httpMethod: .put,
                         parameters: makeParameter(number: number),
                         type: User.self)
-            .bind { status in
-                switch status {
-                case .success(let userData):
-                    guard let userData = userData as? User else { return }
-                    self.userData = userData
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .notFound:
-                    print("This is notFound")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
+        checkUserStatus(requestData: requestedData)
     }
 
     // MARK: - Network Request
@@ -150,6 +103,67 @@ final class NetworkManager {
                 }
             }
             return Disposables.create()
+        }
+    }
+    
+    // TODO: - bind closure 안에서 inout 등 사용법 찾으면 한 함수로 수정(checkStatus)
+    func checkUserStatus(requestData: Observable<NetworkResult<Any>>){
+        requestData.bind { status in
+            switch status {
+            case .success(let data):
+                guard let data = data as? User else { return }
+                self.userData = data
+            case .badRequest:
+                print(TextLiteral.badRequest)
+            case .connectionFail:
+                print(TextLiteral.connectionFail)
+            case .notFound:
+                print(TextLiteral.notFound)
+            case .serverError:
+                print(TextLiteral.serverError)
+            case .networkFail:
+                print(TextLiteral.networkFail)
+            }
+        }
+    }
+    
+    func checkRoomStatus(requestData: Observable<NetworkResult<Any>>) {
+        requestData.bind { status in
+            switch status {
+            case .success(let data):
+                guard let data = data as? Room else { return }
+                self.roomData = data
+            case .badRequest:
+                print(TextLiteral.badRequest)
+            case .connectionFail:
+                print(TextLiteral.connectionFail)
+            case .notFound:
+                print(TextLiteral.notFound)
+            case .serverError:
+                print(TextLiteral.serverError)
+            case .networkFail:
+                print(TextLiteral.networkFail)
+            }
+        }
+    }
+    
+    func checkPostStatus(requestData: Observable<NetworkResult<Any>>) {
+        requestData.bind { status in
+            switch status {
+            case .success(let data):
+                guard let data = data as? Post else { return }
+                self.postData = data
+            case .badRequest:
+                print(TextLiteral.badRequest)
+            case .connectionFail:
+                print(TextLiteral.connectionFail)
+            case .notFound:
+                print(TextLiteral.notFound)
+            case .serverError:
+                print(TextLiteral.serverError)
+            case .networkFail:
+                print(TextLiteral.networkFail)
+            }
         }
     }
 

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -74,57 +74,6 @@ final class NetworkManager {
             }
         }
     }
-    
-    // MARK: - Post
-    
-    func uploadUserData(number: String) {
-        _ = uploadData(url: APIEnvironment.usersURL, number: number, type: User.self)
-            .bind { status in
-                switch status {
-                case .success(let number):
-                    guard let number = number as? User else { return }
-                    self.userData = number
-                case .connectionFail:
-                    print("This is connectionFail")
-                case .reqError:
-                    print("This is requestError")
-                case .serverError:
-                    print("This is serverError")
-                case .networkFail:
-                    print("This is networkFail")
-                }
-            }
-    }
-    
-    func makeParameter(number: String) -> Parameters {
-        return ["number": number]
-    }
-    
-    func uploadData<T: Decodable>(url: String, number: String, type: T.Type) -> Observable<NetworkResult<Any>> {
-        return Observable.create() { observer in
-            AF.request(url,
-                       method: .post,
-                       parameters: self.makeParameter(number: number),
-                       encoding: JSONEncoding.default,
-                       headers: self.header)
-              .responseData { (response) in
-                  switch response.result {
-                  case .success:
-                      guard let data = response.data,
-                            let statusCode = response.response?.statusCode
-                      else { return }
-
-                      let networkResult = self.judgeStatus(by: statusCode,
-                                                           self.isValidData(data: data, type: T.self))
-                      observer.onNext(networkResult)
-                      observer.onCompleted()
-                  case .failure:
-                      break
-                  }
-              }
-            return Disposables.create()
-        }
-    }
 
     // MARK: - Network Request
     

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -71,8 +71,8 @@ final class NetworkManager {
     
     // MARK: - Post
     
-    func uploadUserData(number: String) {
-        _ = requestData(url: APIEnvironment.usersURL,
+    func createUserData(number: String) {
+        let requestedData = requestData(url: APIEnvironment.usersURL,
                         httpMethod: .post,
                         parameters: makeParameter(number: number),
                         type: User.self)

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -28,10 +28,10 @@ final class NetworkManager {
     }
 
     func loadOrCreateData<T: Decodable>(url: String,
-                                httpMethod: HTTPMethod = .get,
-                                parameters: Parameters? = nil,
-                                type: T.Type,
-                                completion: @escaping(T) -> Void) {
+                                        httpMethod: HTTPMethod = .get,
+                                        parameters: Parameters? = nil,
+                                        type: T.Type,
+                                        completion: @escaping(T) -> Void) {
         let requestedData = requestData(url: url,
                                         httpMethod: httpMethod,
                                         parameters: parameters,
@@ -55,7 +55,7 @@ final class NetworkManager {
     }
     
     private func checkStatus<T>(requestData: Observable<NetworkResult<Any>>,
-                        completion: @escaping (T) -> Void) {
+                                completion: @escaping (T) -> Void) {
         requestData.bind { status in
             switch status {
             case .success(let data):
@@ -94,13 +94,13 @@ final class NetworkManager {
     }
     
     private func requestUploadData<T: Decodable> (userID: Int,
-                                          roomID: Int,
-                                          categoryID: Int,
-                                          description: String,
-                                          files: [Data],
-                                          url: String,
-                                          httpMethod: HTTPMethod = .post,
-                                          type: T.Type) -> Observable<NetworkResult<Any>> {
+                                                  roomID: Int,
+                                                  categoryID: Int,
+                                                  description: String,
+                                                  files: [Data],
+                                                  url: String,
+                                                  httpMethod: HTTPMethod = .post,
+                                                  type: T.Type) -> Observable<NetworkResult<Any>> {
         return Observable.create() { observer in
             let header: HTTPHeaders = ["Content-Type": "multipart/form-data",
                                        APIEnvironment.apiField: APIEnvironment.apiKey]

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -131,8 +131,8 @@ final class NetworkManager {
     // MARK: - Network Response
 
     private func checkResponseData<T: Decodable>(request: DataRequest,
-                                         type: T.Type,
-                                         observer: AnyObserver<NetworkResult<Any>>) {
+                                                 type: T.Type,
+                                                 observer: AnyObserver<NetworkResult<Any>>) {
         request.responseData { response in
             switch response.result {
             case .success:


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 불필요하게 반복되는 내용이 매 함수마다 불필요하게 읽혀지는 것을 줄이기 위함.
- 게시물 upload(Post)를 구현하기 위함
- TextLiteral로 휴먼에러를 최소화하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 게시물 upload기능 추가
- 반복 코드 별도 함수로 구분
- ResponseData와 RequestData 함수 구분.
- uploadUserData -> createUserData로 함수명 변경
- TextLiteral로 메시지 형식 변경 -> 붎필요 시 제거

## ToDo 📆 (남은 작업)
- [ ] CheckStatus 함수를 Room, User, Post 모두 가능토록 하나의 함수로 만드는 작업

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 기존과 크게 다르지는 않지만 수정사항이 많습니다. 따라서 file changed보다 xcode로 직접 보시는걸 추천합니다.
- 아래는 사용 예제입니다. 사용하고자 하는 viewController에서 아래와 같은 코드를 작성하시면 됩니다.

```swift
    var viewModel = NetworkManager.shared
    let images = [UIImage(named: "cat")!.pngData()!, UIImage(named: "cat")!.pngData()!]  // 임의 이미지 데이터

        viewModel.loadOrCreateData(url: APIEnvironment.usersURL,  // user정보 생성
                           httpMethod: .post,
                           parameters: ["number": "123456782222"],
                           type: User.self) { data in
            self.viewModel.userData = data
        }

        viewModel.loadOrCreateData(url: APIEnvironment.usersURL + "/2",  // user정보 수정
                           httpMethod: .put,
                           parameters: ["number": "87654"],
                           type: User.self) { data in
            self.viewModel.userData = data
        }

        viewModel.uploadPostData(description: "예제입니다", files: images)  // post 생성
```

## Reference 🔗
[후리스콜링개발 - [iOS] Alamofire Multipart/formdata를 통한 이미지 서버 통신](https://roniruny.tistory.com/148)
[enchantee - Alamofire - Multipart 통신](https://velog.io/@enchantee/Alamofire-Multipart-통신)

[haanwave - You don’t (always) need [weak self]](https://velog.io/@haanwave/Article-You-dont-always-need-weak-self)
[Park gyurim - [Swift] 강한 순환 참조와 해결 방법 (weak, unowned)](https://velog.io/@parkgyurim/Swift-Strong-Reference-Cycle)

## Close Issues 🔒 (닫을 Issue)
Close #36.