### PR TITLE
[Feature] Image Resize 및 Image upload 제한조건 추가

### DIFF
--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -16,7 +16,7 @@ class PostingPhotoCell: UICollectionViewCell {
     static let identifier = "postingPhotoCell"
 
     // MARK: - View
-    
+
     let postingImage: UIImageView = {
         $0.backgroundColor = .systemGray4
         $0.contentMode = .scaleAspectFill
@@ -31,6 +31,14 @@ class PostingPhotoCell: UICollectionViewCell {
         $0.tintColor = .white
         return $0
     }(UIImageView())
+    
+    let resolutionLabel: UILabel = {
+        $0.text = TextLiteral.resolutionText
+        $0.textColor = .white
+        $0.textAlignment = .center
+        $0.font = UIFont.systemFont(ofSize: 15, weight: .bold)
+        return $0
+    }(UILabel())
     
     // MARK: - LifeCycle
 
@@ -55,6 +63,12 @@ class PostingPhotoCell: UICollectionViewCell {
         plusIcon.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.size.equalTo(50)
+        }
+        
+        postingImage.addSubview(resolutionLabel)
+        resolutionLabel.snp.makeConstraints {
+            $0.top.equalTo(plusIcon.snp.bottom).offset(10)
+            $0.horizontalEdges.equalToSuperview()
         }
     }
 }

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -26,13 +26,15 @@ class PostingPhotoCell: UICollectionViewCell {
         return $0
     }(UIImageView())
     
-    let plusIcon: UIImageView = {
+    let contents = UIView()
+    
+    private let plusIcon: UIImageView = {
         $0.image = UIImage(systemName: "plus")
         $0.tintColor = .white
         return $0
     }(UIImageView())
     
-    let resolutionLabel: UILabel = {
+    private let resolutionLabel: UILabel = {
         $0.text = TextLiteral.resolutionText
         $0.textColor = .white
         $0.textAlignment = .center
@@ -54,20 +56,26 @@ class PostingPhotoCell: UICollectionViewCell {
     // MARK: - Method
     
     private func setupCell() {
-        self.addSubview(postingImage)
+        addSubview(postingImage)
         postingImage.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
         
-        postingImage.addSubview(plusIcon)
-        plusIcon.snp.makeConstraints {
+        postingImage.addSubview(contents)
+        contents.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.size.equalTo(50)
         }
         
-        postingImage.addSubview(resolutionLabel)
+        contents.addSubview(plusIcon)
+        plusIcon.snp.makeConstraints {
+            $0.top.centerX.equalToSuperview()
+            $0.size.equalTo(super.frame.height/3)
+        }
+        
+        contents.addSubview(resolutionLabel)
         resolutionLabel.snp.makeConstraints {
             $0.top.equalTo(plusIcon.snp.bottom).offset(10)
+            $0.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
     }

--- a/GiwazipClient/Cells/PostingPhotoCell.swift
+++ b/GiwazipClient/Cells/PostingPhotoCell.swift
@@ -34,8 +34,8 @@ class PostingPhotoCell: UICollectionViewCell {
         return $0
     }(UIImageView())
     
-    private let resolutionLabel: UILabel = {
-        $0.text = TextLiteral.resolutionText
+    private let minimumResolutionText: UILabel = {
+        $0.text = TextLiteral.minimumResolutionText
         $0.textColor = .white
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 15, weight: .bold)
@@ -72,8 +72,8 @@ class PostingPhotoCell: UICollectionViewCell {
             $0.size.equalTo(super.frame.height/3)
         }
         
-        contents.addSubview(resolutionLabel)
-        resolutionLabel.snp.makeConstraints {
+        contents.addSubview(minimumResolutionText)
+        minimumResolutionText.snp.makeConstraints {
             $0.top.equalTo(plusIcon.snp.bottom).offset(10)
             $0.bottom.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()

--- a/GiwazipClient/Literals/TextLiteral.swift
+++ b/GiwazipClient/Literals/TextLiteral.swift
@@ -38,6 +38,11 @@ enum TextLiteral {
 
     // MARK: - PostingPhotoView
 
+    static let guidanceText = """
+                              문의할 사진을 추가해주세요.
+                              (최대 5장까지 선택 가능합니다.)
+                              """
+    static let navigationTitle = "시공사진 추가"
     static let nextButtonText = "다음"
 
     static let photoChangeText = "사진 변경하기"
@@ -115,4 +120,8 @@ enum TextLiteral {
     // MARK: - ASCell
 
     static let remainText = "남았어요"
+    
+    // MARK: - PostingPhotoCell
+    
+    static let resolutionText =  "최소 이미지 가로(400픽셀), 세로(400픽셀) 이상"
 }

--- a/GiwazipClient/Literals/TextLiteral.swift
+++ b/GiwazipClient/Literals/TextLiteral.swift
@@ -42,6 +42,15 @@ enum TextLiteral {
 
     static let photoChangeText = "사진 변경하기"
     static let photoDeleteText = "사진 삭제하기"
+    
+    static let minimumSizeAlertMessage = """
+                                         이미지의 최소 가로 x 세로 크기는
+                                         400 x 400 이상이어야 합니다.
+                                         """
+    static let unnormalSizeAlertMessage = """
+                                          정상비율의 이미지가 아닙니다.
+                                          다시 확인해주시기 바랍니다.
+                                          """
 
     // MARK: - PostingTextView
 

--- a/GiwazipClient/Literals/TextLiteral.swift
+++ b/GiwazipClient/Literals/TextLiteral.swift
@@ -38,11 +38,11 @@ enum TextLiteral {
 
     // MARK: - PostingPhotoView
 
-    static let guidanceText = """
-                              문의할 사진을 추가해주세요.
-                              (최대 5장까지 선택 가능합니다.)
-                              """
-    static let navigationTitle = "시공사진 추가"
+    static let photoUploadGuidanceText = """
+                                         문의할 사진을 추가해주세요.
+                                         (최대 5장까지 선택 가능합니다.)
+                                         """
+    static let postingPhotoViewNavigationTitle = "시공사진 추가"
     static let nextButtonText = "다음"
 
     static let photoChangeText = "사진 변경하기"
@@ -59,6 +59,8 @@ enum TextLiteral {
 
     // MARK: - PostingTextView
 
+    static let postingTextViewNavigationTitle = "시공내용 작성"
+    
     static let textViewPlaceHolder = """
                                      예시)
                                      - 화장실이 빨강색이면 좋겠어요~!
@@ -123,5 +125,5 @@ enum TextLiteral {
     
     // MARK: - PostingPhotoCell
     
-    static let resolutionText =  "최소 이미지 가로(400픽셀), 세로(400픽셀) 이상"
+    static let minimumResolutionText =  "최소 이미지 가로(400픽셀), 세로(400픽셀) 이상"
 }

--- a/GiwazipClient/ViewModels/NetworkManager.swift
+++ b/GiwazipClient/ViewModels/NetworkManager.swift
@@ -119,7 +119,7 @@ final class NetworkManager {
                     let photo = files[i]
                     multipartFormData.append(photo,
                                              withName: "files",
-                                             fileName: "\(userID)0\(i + 1).png")
+                                             fileName: "\(userID)0\(i + 1).jpeg")
                 }
             }, to: url, usingThreshold: UInt64.init(), method: httpMethod, headers: header)
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -67,7 +67,16 @@ class PostingPhotoViewController: BaseViewController {
     override func attribute() {
         super.attribute()
 
+        setupNavigationBar()
         setupCollectionView()
+    }
+    
+    private func setupNavigationBar() {
+        let backBarButtonItem = UIBarButtonItem(title: TextLiteral.cancelButtonText, style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .blue
+        navigationItem.leftBarButtonItem = backBarButtonItem
+        navigationItem.title = TextLiteral.navigationTitle
+        navigationController?.setNavigationBarHidden(false, animated: true)
     }
 
     private func setupCollectionView() {
@@ -126,8 +135,8 @@ class PostingPhotoViewController: BaseViewController {
 
     @objc func didTapNextButton() {
         convertImageToData()
-        
         let postingTextViewController = PostingTextViewController()
+        postingTextViewController.imageDatas = imageDatas
         navigationController?.pushViewController(postingTextViewController, animated: true)
     }
     

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -125,10 +125,12 @@ class PostingPhotoViewController: BaseViewController {
         photoCollectionView.reloadData()
     }
     
-    func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
-        // TODO: 세로길이가 길었을 때에 대해서도 고려를 해야할까? 가로 비율에 맞게 세로도 줄어들긴 하는데...
-        if image.size.width > 800 {
-            let scale = newWidth / image.size.width
+    func resizeImage(image: UIImage, newSize: CGFloat = 880) -> UIImage {
+        let maxSize = max(image.size.width, image.size.height)
+
+        if maxSize > newSize {
+            let scale = newSize / maxSize
+            let newWidth = image.size.width * scale
             let newHeight = image.size.height * scale
             
             let size = CGSize(width: newWidth, height: newHeight)
@@ -210,12 +212,13 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
             if item.canLoadObject(ofClass: UIImage.self) {
                 item.loadObject(ofClass: UIImage.self) { (image, _) in
                     DispatchQueue.main.async {
-                        guard var image = image as? UIImage else { return }
-                        image = self.resizeImage(image: image, newWidth: 800)
+                        guard let image = image as? UIImage else { return }
+
                         if self.isChangedPHPickerRole {
-                            self.images.insert(image, at: self.selectedIndex + 1)
+                            self.images.insert(self.resizeImage(image: image),
+                                               at: self.selectedIndex + 1)
                         } else {
-                            self.images[self.selectedIndex] = image
+                            self.images[self.selectedIndex] = self.resizeImage(image: image)
                         }
                         self.photoCollectionView.reloadData()
                     }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -190,8 +190,7 @@ extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionVi
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingPhotoCell.identifier, for: indexPath) as! PostingPhotoCell
 
-        cell.plusIcon.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
-        cell.resolutionLabel.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
+        cell.contents.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
 
         if images.count == 6 {
             images.remove(at: 0)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -10,19 +10,18 @@ import UIKit
 
 import SnapKit
 
-protocol PostingPhotoViewControllerDelegate {
-    
-}
-
 class PostingPhotoViewController: BaseViewController {
 
     // MARK: - Property
 
     var delegate: PostingPhotoViewControllerDelegate?
+    
     private var buttonConfiguration = UIButton.Configuration.filled()
     private var pickerConfiguration = PHPickerConfiguration()
+    
     private var isChangedPHPickerRole = false
     private var selectedIndex = 0
+    
     private let emptyImage = UIImage()
     private var imageDatas: [Data] = []
     private lazy var images: [UIImage] = [emptyImage] {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -18,12 +18,14 @@ class PostingPhotoViewController: BaseViewController {
 
     // MARK: - Property
 
+    var viewModel = NetworkManager.shared
     var delegate: PostingPhotoViewControllerDelegate?
     private var buttonConfiguration = UIButton.Configuration.filled()
     private var pickerConfiguration = PHPickerConfiguration()
     private var isChangedPHPickerRole = false
     private var selectedIndex = 0
     private let emptyImage = UIImage()
+    private var imageDatas: [Data] = []
 
     private lazy var images: [UIImage] = [emptyImage] {
         didSet {
@@ -59,6 +61,7 @@ class PostingPhotoViewController: BaseViewController {
         $0.configuration?.baseBackgroundColor = .blue
         $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
+        $0.addTarget(self, action: #selector(uploadPostData), for: .touchUpInside)
         $0.isEnabled = false
         return $0
     }(UIButton(configuration: buttonConfiguration))
@@ -125,6 +128,15 @@ class PostingPhotoViewController: BaseViewController {
         photoCollectionView.reloadData()
     }
     
+    @objc func uploadPostData() {
+        images.forEach {
+            if $0 != UIImage() {
+                imageDatas.append($0.jpegData(compressionQuality: 1/3)!)
+            }
+        }
+        viewModel.uploadPostData(description: "10차 테스트입니다.", files: imageDatas)
+    }
+
     func resizeImage(image: UIImage, newSize: CGFloat = 880) -> UIImage {
         let maxSize = max(image.size.width, image.size.height)
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -142,6 +142,20 @@ class PostingPhotoViewController: BaseViewController {
         }
         return image
     }
+    
+    func CancelOrAddImage(image: UIImage) {
+        switch image != UIImage() {
+        case (image.size.width, image.size.height) < (400, 400):
+            self.makeAlert(message: TextLiteral.minimumSizeAlertMessage)
+        case (self.resizeImage(image: image).size.width,
+              self.resizeImage(image: image).size.height) < (400, 400):
+            self.makeAlert(message: TextLiteral.unnormalSizeAlertMessage)
+        case self.isChangedPHPickerRole:
+            self.images.insert(self.resizeImage(image: image), at: self.selectedIndex + 1)
+        default:
+            self.images[self.selectedIndex] = self.resizeImage(image: image)
+        }
+    }
 }
 
 extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -213,13 +227,7 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
                 item.loadObject(ofClass: UIImage.self) { (image, _) in
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
-
-                        if self.isChangedPHPickerRole {
-                            self.images.insert(self.resizeImage(image: image),
-                                               at: self.selectedIndex + 1)
-                        } else {
-                            self.images[self.selectedIndex] = self.resizeImage(image: image)
-                        }
+                        self.CancelOrAddImage(image: image)
                         self.photoCollectionView.reloadData()
                     }
                 }

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -124,6 +124,22 @@ class PostingPhotoViewController: BaseViewController {
         images.remove(at: selectedIndex)
         photoCollectionView.reloadData()
     }
+    
+    func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
+        // TODO: 세로길이가 길었을 때에 대해서도 고려를 해야할까? 가로 비율에 맞게 세로도 줄어들긴 하는데...
+        if image.size.width > 800 {
+            let scale = newWidth / image.size.width
+            let newHeight = image.size.height * scale
+            
+            let size = CGSize(width: newWidth, height: newHeight)
+            let render = UIGraphicsImageRenderer(size: size)
+            let renderImage = render.image { context in
+                image.draw(in: CGRect(origin: .zero, size: size))
+            }
+            return renderImage
+        }
+        return image
+    }
 }
 
 extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -194,8 +210,8 @@ extension PostingPhotoViewController: PHPickerViewControllerDelegate {
             if item.canLoadObject(ofClass: UIImage.self) {
                 item.loadObject(ofClass: UIImage.self) { (image, _) in
                     DispatchQueue.main.async {
-                        guard let image = image as? UIImage else { return }
-
+                        guard var image = image as? UIImage else { return }
+                        image = self.resizeImage(image: image, newWidth: 800)
                         if self.isChangedPHPickerRole {
                             self.images.insert(image, at: self.selectedIndex + 1)
                         } else {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -175,10 +175,10 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     private func checkAndUploadImage(image: UIImage) {
-        if let resizeImage = UIImage(data: resizeImage(image: image)) {
-            if (image.size.width < 400) || (image.size.height < 400) {
-                makeAlert(message: TextLiteral.minimumSizeAlertMessage)
-            } else if (resizeImage.size.width < 400) || (resizeImage.size.height < 400) {
+        if (image.size.width < 400) || (image.size.height < 400) {
+            makeAlert(message: TextLiteral.minimumSizeAlertMessage)
+        } else if let resizeImage = UIImage(data: resizeImage(image: image)) {
+            if (resizeImage.size.width < 400) || (resizeImage.size.height < 400) {
                 makeAlert(message: TextLiteral.unnormalSizeAlertMessage)
             } else if isChangedPHPickerRole {
                 images.insert(resizeImage, at: selectedIndex + 1)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -25,7 +25,6 @@ class PostingPhotoViewController: BaseViewController {
     private var selectedIndex = 0
     private let emptyImage = UIImage()
     private var imageDatas: [Data] = []
-
     private lazy var images: [UIImage] = [emptyImage] {
         didSet {
             nextButton.isEnabled = (images.count > 1) ? true : false
@@ -141,6 +140,8 @@ class PostingPhotoViewController: BaseViewController {
     }
     
     @objc func convertImageToData() {
+        imageDatas = []
+        
         images.forEach {
             if $0 != UIImage() {
                 imageDatas.append($0.jpegData(compressionQuality: 1/3)!)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -36,10 +36,7 @@ class PostingPhotoViewController: BaseViewController {
     // MARK: - View
 
     private let guidanceLabel: UILabel = {
-        $0.text = """
-                  문의할 사진을 추가해주세요.
-                  (최대 5장까지 선택 가능합니다.)
-                  """
+        $0.text = TextLiteral.guidanceText
         $0.textColor = .gray
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
@@ -179,6 +176,7 @@ extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionVi
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostingPhotoCell.identifier, for: indexPath) as! PostingPhotoCell
 
         cell.plusIcon.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
+        cell.resolutionLabel.isHidden = (indexPath.item == 0 && images[0] == emptyImage) ? false : true
 
         if images.count == 6 {
             images.remove(at: 0)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -18,7 +18,6 @@ class PostingPhotoViewController: BaseViewController {
 
     // MARK: - Property
 
-    var viewModel = NetworkManager.shared
     var delegate: PostingPhotoViewControllerDelegate?
     private var buttonConfiguration = UIButton.Configuration.filled()
     private var pickerConfiguration = PHPickerConfiguration()
@@ -132,16 +131,15 @@ class PostingPhotoViewController: BaseViewController {
         navigationController?.pushViewController(postingTextViewController, animated: true)
     }
     
-    @objc func uploadPostData() {
+    @objc func convertImageToData() {
         images.forEach {
             if $0 != UIImage() {
                 imageDatas.append($0.jpegData(compressionQuality: 1/3)!)
             }
         }
-        viewModel.uploadPostData(description: "10차 테스트입니다.", files: imageDatas)
     }
 
-    func resizeImage(image: UIImage, newSize: CGFloat = 880) -> UIImage {
+    private func resizeImage(image: UIImage, newSize: CGFloat = 880) -> UIImage {
         let maxSize = max(image.size.width, image.size.height)
 
         if maxSize > newSize {
@@ -159,7 +157,7 @@ class PostingPhotoViewController: BaseViewController {
         return image
     }
     
-    func CancelOrAddImage(image: UIImage) {
+    private func CancelOrAddImage(image: UIImage) {
         switch image != UIImage() {
         case (image.size.width, image.size.height) < (400, 400):
             self.makeAlert(message: TextLiteral.minimumSizeAlertMessage)

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -61,7 +61,7 @@ class PostingPhotoViewController: BaseViewController {
         return $0
     }(UIButton(configuration: buttonConfiguration))
 
-    // MARK: - Method
+    // MARK: - Attribute
 
     override func attribute() {
         super.attribute()
@@ -84,6 +84,8 @@ class PostingPhotoViewController: BaseViewController {
         photoCollectionView.register(PostingPhotoCell.self,
                                      forCellWithReuseIdentifier: PostingPhotoCell.identifier)
     }
+    
+    // MARK: - Layout
     
     override func layout() {
         super.layout()
@@ -109,6 +111,8 @@ class PostingPhotoViewController: BaseViewController {
         }
     }
 
+    // MARK: - PHPicker
+    
     private func setupPHPickerConfigure() {
         pickerConfiguration.selection = .ordered
         pickerConfiguration.selectionLimit = (6 - images.count)
@@ -132,6 +136,8 @@ class PostingPhotoViewController: BaseViewController {
         photoCollectionView.reloadData()
     }
 
+    // MARK: - NextButton Action
+
     @objc func didTapNextButton() {
         convertImageToData()
         let postingTextViewController = PostingTextViewController()
@@ -150,6 +156,8 @@ class PostingPhotoViewController: BaseViewController {
     }
 
     private func resizeImage(image: UIImage, newSize: CGFloat = 880) -> UIImage {
+    // MARK: - Image
+    
         let maxSize = max(image.size.width, image.size.height)
 
         if maxSize > newSize {
@@ -181,6 +189,8 @@ class PostingPhotoViewController: BaseViewController {
         }
     }
 }
+
+// MARK: - UICollectionViewDataSource, UICollectionViewDelegateFlowLayout
 
 extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -238,6 +248,8 @@ extension PostingPhotoViewController: UICollectionViewDataSource, UICollectionVi
         return 20
     }
 }
+
+// MARK: - PHPickerViewControllerDelegate
 
 extension PostingPhotoViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -33,8 +33,8 @@ class PostingPhotoViewController: BaseViewController {
 
     // MARK: - View
 
-    private let guidanceLabel: UILabel = {
-        $0.text = TextLiteral.guidanceText
+    private let photoUploadGuidanceText: UILabel = {
+        $0.text = TextLiteral.photoUploadGuidanceText
         $0.textColor = .gray
         $0.textAlignment = .center
         $0.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
@@ -74,7 +74,7 @@ class PostingPhotoViewController: BaseViewController {
         let backBarButtonItem = UIBarButtonItem(title: TextLiteral.cancelButtonText, style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .blue
         navigationItem.leftBarButtonItem = backBarButtonItem
-        navigationItem.title = TextLiteral.navigationTitle
+        navigationItem.title = TextLiteral.postingPhotoViewNavigationTitle
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
 
@@ -90,15 +90,15 @@ class PostingPhotoViewController: BaseViewController {
     override func layout() {
         super.layout()
 
-        view.addSubview(guidanceLabel)
-        guidanceLabel.snp.makeConstraints {
+        view.addSubview(photoUploadGuidanceText)
+        photoUploadGuidanceText.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(12)
             $0.centerX.equalToSuperview()
         }
 
         view.addSubview(photoCollectionView)
         photoCollectionView.snp.makeConstraints {
-            $0.top.equalTo(guidanceLabel.snp.bottom).offset(16)
+            $0.top.equalTo(photoUploadGuidanceText.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview()
         }
 

--- a/GiwazipClient/Views/PostingPhotoViewController.swift
+++ b/GiwazipClient/Views/PostingPhotoViewController.swift
@@ -52,13 +52,13 @@ class PostingPhotoViewController: BaseViewController {
     }()
 
     private lazy var nextButton: UIButton = {
-        $0.configuration?.title = "다음"
+        $0.configuration?.title = TextLiteral.nextButtonText
         $0.configuration?.attributedTitle?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         $0.configuration?.baseForegroundColor = .white
         $0.configuration?.baseBackgroundColor = .blue
         $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
-        $0.addTarget(self, action: #selector(uploadPostData), for: .touchUpInside)
+        $0.addTarget(self, action: #selector(didTapNextButton), for: .touchUpInside)
         $0.isEnabled = false
         return $0
     }(UIButton(configuration: buttonConfiguration))
@@ -123,6 +123,13 @@ class PostingPhotoViewController: BaseViewController {
     private func didTapDeleteAction() {
         images.remove(at: selectedIndex)
         photoCollectionView.reloadData()
+    }
+
+    @objc func didTapNextButton() {
+        convertImageToData()
+        
+        let postingTextViewController = PostingTextViewController()
+        navigationController?.pushViewController(postingTextViewController, animated: true)
     }
     
     @objc func uploadPostData() {

--- a/GiwazipClient/Views/PostingTextViewController.swift
+++ b/GiwazipClient/Views/PostingTextViewController.swift
@@ -14,6 +14,8 @@ class PostingTextViewController: BaseViewController {
     // MARK: - Property
     
     private let textViewPlaceHolder: String = TextLiteral.textViewPlaceHolder
+    private let viewModel = NetworkManager.shared
+    var imageDatas: [Data] = []
     
     // MARK: - View
     
@@ -46,6 +48,7 @@ class PostingTextViewController: BaseViewController {
         $0.configuration?.background.cornerRadius = 0
         $0.configuration?.contentInsets.bottom = 20
         $0.isEnabled = false
+        $0.addTarget(self, action: #selector(tapInquiryButton), for: .touchUpInside)
         return $0
     }(UIButton())
     
@@ -75,6 +78,15 @@ class PostingTextViewController: BaseViewController {
     override func attribute() {
         super.attribute()
         setupNotificationCenter()
+        setupNavigationBar()
+    }
+    
+    private func setupNavigationBar() {
+        navigationItem.title = "시공내용 작성"
+    }
+    
+    @objc func tapInquiryButton() {
+        viewModel.uploadPostData(description: textView.text, files: imageDatas)
     }
     
     private func setupNotificationCenter() {

--- a/GiwazipClient/Views/PostingTextViewController.swift
+++ b/GiwazipClient/Views/PostingTextViewController.swift
@@ -77,12 +77,9 @@ class PostingTextViewController: BaseViewController {
     
     override func attribute() {
         super.attribute()
-        setupNotificationCenter()
-        setupNavigationBar()
-    }
-    
-    private func setupNavigationBar() {
         navigationItem.title = "시공내용 작성"
+        
+        setupNotificationCenter()
     }
     
     @objc func tapInquiryButton() {

--- a/GiwazipClient/Views/PostingTextViewController.swift
+++ b/GiwazipClient/Views/PostingTextViewController.swift
@@ -77,7 +77,7 @@ class PostingTextViewController: BaseViewController {
     
     override func attribute() {
         super.attribute()
-        navigationItem.title = "시공내용 작성"
+        navigationItem.title = TextLiteral.postingTextViewNavigationTitle
         
         setupNotificationCenter()
     }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 이미지에 의한 서버 부하 감소
- 이미지 JPEG 확장자 고정
- UX를 위한 이미지 최소 해상도 조건 추가
  - 해상도가 지나치게 낮은 사진 업로드 예방
- 이미지 해상도 및 비율 문제 최소화
- 사용자에게 최소 이미지 해상도 가이드 제공
- 이미지 및 설명글 Post
- 데이터 중첩 방지

## Key Changes 🔥 (주요 구현/변경 사항)
- [x] 이미지 사이즈 감소
  - **`UIGraphicsImageRenderer`** 방식 사용
  - 기존 블로그 내용과 달리 downSampling 대비 CPU, Memory 사용량이 낮으며, 변환 속도가 빠름.
    - **추측**: downSampling은  이미지를 로컬에 없는 이미지를 불러올 때보다 로컬 이미지를 서버에 Post 할 때 유용한 것 같다.
  - (구) resize방식인 **`UIGraphicsBeginImageContext`** 에 비해 의미가 **`명확한 코드`** 이며, 더 **`이해하기 용이함`**
  - 가로, 세로가 880보다 큰 이미지에 한하여 **`가장 긴 축을 880으로 렌더링`** 후, 비율(scale) 반영.
- [x] 이미지 확장자 제한
  - **`JPEG 고정`** (HEIF, JPG, PNG 테스트 완료, HEIC 이미지를 확보하지 못해 테스트 미실시)
- [x] 텍스트리터럴 추가
- [x] 이미지 **`최소 해상도 조건 추가`**
- [x] 리사이즈 이미지 문제 발생에 따른 조건 추가
- [x] 이미지 조건 부합하지 않을 시 이미지 **`업로드 제한`**
  - 최소 해상도 미달되었다는 알림 추가
  - 최소 해상도 가로 400, 세로 400보다 낮을 때 업로드 제한
  - 리사이즈 후 짧은 축이 최소 해상도보다 낮을 때 업로드 제한
- [x] **`PostingPhotoVC`** -> **`PostingTextVC`** 로 이미지데이터 바인딩
- [x] PostingTextVC **`이미지, 설명글 서버 업로드 기능 추가`**
- [x] PostingPhotoVC -> PostingTextVC 왕복 시, **`데이터 중첩 방지`**
- [x] PostingPhotoVC, PostingTextVC **`네비게이션 타이틀 추가`**
- [x] PostingPhotoView에 **`최소 해상도 가이드 추가`**

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
- 카톡 영상으로 대체. 1분여의 영상으로 깃허브 용량제한.
![image](https://user-images.githubusercontent.com/98405970/223634492-aa03ef91-99e0-427e-8fe1-6da8faea14ed.png)
< 이미지 처리 프로세스 >
- 코드: 원하는 이미지비율을 정하기 -> 이미지 렌더링 끝!
- 내부: UIImage -> Decoding -> imageRender (Decoding작업 간 Memory 및 CPU 소모량이 높아짐)
## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 아직까진 버그가 발견되지 않았습니다. 버그 발견시 알려주시면 감사하겠습니다.
- **Resize이미지를 jpegData로 변환 시 width, height가 3배씩 증가하는 문제**가 있었습니다. 원인은 아직 잘 모르겠으나, jpeg가 24bit RGB방식을 사용한 손실압축방식을 사용하고 있고, UIGraphicsImageRenderer방식은 8bit방식을 사용하고 있어서 그런게 아닐까? 라는 생각입니다. 다른 의견 있으면 코멘트 달아주시면 감사하겠습니다.
- 원래 Task는 PostingPhotoView에 관한 내용만이었지만, 연결된 뷰라서 한번에 하는 게 낫다 생각해 추가 Task를 가져갔네요. 그래도 코드는 길지 않고, 어려운 코드도 없으니 가볍게 확인하셔도 될 것 같습니다.

- 실행을 위한 SceneDelegate 코드입니다.
```swift 
    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {

        _ = NetworkManager.shared

        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2) {

            guard let scene = (scene as? UIWindowScene) else { return }
            self.window = UIWindow(windowScene: scene)

            let navigationController = UINavigationController(rootViewController: PostingPhotoViewController())
            self.window?.rootViewController = navigationController

            self.window?.makeKeyAndVisible()
        }
    }
```
## Reference 🔗
[NamS의 iOS일기 - Image Resize](https://nsios.tistory.com/154)

## Close Issues 🔒 (닫을 Issue)
Close #61.
